### PR TITLE
[feat] PetInfo 공통 컴포넌트 구현

### DIFF
--- a/apps/duri/src/App.tsx
+++ b/apps/duri/src/App.tsx
@@ -7,6 +7,7 @@ import { Global } from '@emotion/react';
 
 import Home from '@pages/Home';
 import LoginPage from '@pages/Login';
+import MyPage from '@pages/My';
 import StartPage from '@pages/Onboarding/StartPage';
 import PaymentPage from '@pages/Payment';
 import FailPage from '@pages/Payment/Fail';
@@ -15,10 +16,8 @@ import QuotationPage from '@pages/Quotation';
 import QuotationDetailPage from '@pages/QuotationDetail';
 import RequestPage from '@pages/Request';
 import Shop from '@pages/Shop';
-
-import MyPage from './pages/My';
-import Portfolio from './pages/Shop/Portfolio';
-import ShopDetail from './pages/Shop/ShopDetail';
+import Portfolio from '@pages/Shop/Portfolio';
+import ShopDetail from '@pages/Shop/ShopDetail';
 
 function App() {
   return (

--- a/apps/duri/src/App.tsx
+++ b/apps/duri/src/App.tsx
@@ -15,8 +15,10 @@ import QuotationPage from '@pages/Quotation';
 import QuotationDetailPage from '@pages/QuotationDetail';
 import RequestPage from '@pages/Request';
 import Shop from '@pages/Shop';
-import Portfolio from '@pages/Shop/Portfolio';
-import ShopDetail from '@pages/Shop/ShopDetail';
+
+import MyPage from './pages/My';
+import Portfolio from './pages/Shop/Portfolio';
+import ShopDetail from './pages/Shop/ShopDetail';
 
 function App() {
   return (
@@ -33,13 +35,18 @@ function App() {
         <Route path="/payment" element={<PaymentPage />} />
         <Route path="/payment/success" element={<SuccessPage />} />
         <Route path="/payment/fail" element={<FailPage />} />
+        
         <Route path="/shop/request" element={<RequestPage />} />
         <Route path="/shop" element={<Shop />} />
         <Route path="/shop/:shopId" element={<ShopDetail />} />
+        
         <Route path="/portfolio/:designerId" element={<Portfolio />} />
 
         <Route path="/quotation" element={<QuotationPage />} />
         <Route path="/quotation/:quotationId" element={<QuotationDetailPage />} />
+        
+        <Route path="/my" element={<MyPage />} />
+
       </Routes>
     </BrowserRouter>
   );

--- a/apps/duri/src/assets/data/pet.ts
+++ b/apps/duri/src/assets/data/pet.ts
@@ -1,10 +1,29 @@
 export const defaultPetInfo = {
-    petId: null,
-    name: '',
-    imageURL: null,
-    breed: '',
-    age: -1,
-    weight: -1,
-    gender: '',
-    lastGrooming: null
-}
+  petId: undefined,
+  name: '',
+  image: undefined,
+  breed: '',
+  age: -1,
+  weight: -1,
+  gender: '',
+  lastGrooming: undefined,
+};
+
+// 성격 매핑
+export const personalityOptions = [
+  { key: 'character1', label: '예민해요' },
+  { key: 'character2', label: '낯가려요' },
+  { key: 'character3', label: '입질이 있어요' },
+  { key: 'character4', label: '사람을 좋아해요' },
+  { key: 'character5', label: '얌전해요' },
+  { key: 'character6', label: '낯선 손길은 무서워요' },
+];
+
+//질환 매핑
+export const diseaseOptions = [
+    {key: 'disease1', label: '피부 질환'},
+    {key: 'disease2', label: '귀 염증'},
+    {key: 'disease3', label: '관절 질환'},
+    {key: 'disease4', label: '기저 질환'},
+    {key: 'disease5', label: '딱히 없어요'},
+  ];

--- a/apps/duri/src/assets/data/request.ts
+++ b/apps/duri/src/assets/data/request.ts
@@ -1,5 +1,5 @@
 export const defaultRequestInfo = {
-  petId: null,
+  petId: undefined,
   menu: [],
   addMenu: [],
   specialMenu: [],

--- a/apps/duri/src/assets/types/pet.ts
+++ b/apps/duri/src/assets/types/pet.ts
@@ -6,5 +6,5 @@ export interface PetInfoType {
   age: number;
   weight: number;
   gender: string;
-  lastGrooming: string | null;
+  lastGrooming?: string;
 }

--- a/apps/duri/src/assets/types/pet.ts
+++ b/apps/duri/src/assets/types/pet.ts
@@ -1,6 +1,6 @@
 export interface PetInfoType {
-  petId: number | null;
-  imageURL: string | null;
+  petId?: number;
+  image?: string;
   name: string;
   breed: string;
   age: number;

--- a/apps/duri/src/assets/types/request.ts
+++ b/apps/duri/src/assets/types/request.ts
@@ -1,5 +1,5 @@
 export interface RequestType extends TimeType {
-  petId: number | null;
+  petId?: number;
   menu: string[];
   addMenu: string[];
   specialMenu: string[];

--- a/apps/duri/src/components/home/Home.tsx
+++ b/apps/duri/src/components/home/Home.tsx
@@ -21,7 +21,7 @@ const CarouselHome = ({
   lastReservation,
 }: {
   upcomingReservation?: UpcomingReservationProps;
-  lastReservation: string | null;
+  lastReservation?: string;
 }) => {
   const [swiperIndex, setSwiperIndex] = useState<number>(0); // 슬라이드 인덱스 상태
   const currentDate = new Date();

--- a/apps/duri/src/components/onboarding/PetDiseaseInfo.tsx
+++ b/apps/duri/src/components/onboarding/PetDiseaseInfo.tsx
@@ -1,5 +1,6 @@
 import { Control, Controller } from 'react-hook-form';
 
+import { diseaseOptions } from '@duri/assets/data/pet';
 import { Button, Flex, Text, theme } from '@duri-fe/ui';
 
 import { FormData } from '.';
@@ -17,13 +18,7 @@ const PetDiseaseInfo = ({
   name,
   diseaseList,
 }: PetDiseaseInfoProps) => {
-  const diseaseOptions = [
-    '피부 질환',
-    '귀 염증',
-    '관절 질환',
-    '기저 질환',
-    '딱히 없어요',
-  ];
+
 
   // 성격 선택 토글 처리 함수
   const handleToggle = (value: string) => {
@@ -60,30 +55,30 @@ const PetDiseaseInfo = ({
               입력된 성격은 MY에서 변경가능해요.
             </Text>
             <Flex direction="column" align="flex-start" gap={8} margin='47px 0'>
-              {diseaseOptions.map((value) => (
+              {diseaseOptions.map(({key, label}) => (
                 <Button
-                  key={value}
+                  key={key}
                   typo='Body3'
                   width="fit-content"
                   height="43px"
                   bg={
-                    diseaseList.includes(value)
+                    diseaseList.includes(key)
                       ? theme.palette.Black
                       : theme.palette.White
                   }
                   fontColor={
-                    diseaseList.includes(value)
+                    diseaseList.includes(key)
                       ? theme.palette.White
                       : theme.palette.Black
                   }
                   border={
-                    diseaseList.includes(value)
+                    diseaseList.includes(key)
                       ? 'none'
                       : `1px solid ${theme.palette.Gray100}`
                   }
-                  onClick={() => handleToggle(value)}
+                  onClick={() => handleToggle(key)}
                 >
-                  {value}
+                  {label}
                 </Button>
               ))}
             </Flex>

--- a/apps/duri/src/components/onboarding/PetPersonalityInfo.tsx
+++ b/apps/duri/src/components/onboarding/PetPersonalityInfo.tsx
@@ -1,5 +1,6 @@
 import { Control, Controller } from 'react-hook-form';
 
+import { personalityOptions } from '@duri/assets/data/pet';
 import { Button, Flex, Text, theme } from '@duri-fe/ui';
 import styled from '@emotion/styled';
 
@@ -18,26 +19,18 @@ const PetPersonalityInfo = ({
   personalityList, // 상위에서 전달된 리스트 사용
   name,
 }: PetPersonalityInfoProps) => {
-  // 성격 목록
-  const personalityOptions = [
-    '예민해요',
-    '낯가려요',
-    '입질이 있어요',
-    '사람을 좋아해요',
-    '얌전해요',
-    '낯선 손길은 무서워요',
-  ];
+
 
   // 성격 선택 토글 처리 함수
-  const handleToggle = (value: string) => {
+  const handleToggle = (key: string) => {
     const currentValues = [...personalityList]; // 현재 선택된 값들을 복사
 
-    if (currentValues.includes(value)) {
+    if (currentValues.includes(key)) {
       // 이미 포함된 값이면 제거
-      toggleArrayValue('character', value); // 상위에서 상태 업데이트
+      toggleArrayValue('character', key); // 상위에서 상태 업데이트
     } else {
       // 포함되지 않은 값이면 추가
-      toggleArrayValue('character', value); // 상위에서 상태 업데이트
+      toggleArrayValue('character', key); // 상위에서 상태 업데이트
     }
   };
 
@@ -63,30 +56,30 @@ const PetPersonalityInfo = ({
         }}
         render={() => (
           <FitFlex justify="flex-start" gap={8} margin="47px 0">
-            {personalityOptions.map((value) => (
+            {personalityOptions.map(({key, label}) => (
               <Button
-                key={value}
+                key={key}
                 typo="Body3"
                 width="fit-content"
                 height="43px"
                 bg={
-                  personalityList.includes(value)
+                  personalityList.includes(key)
                     ? theme.palette.Black
                     : theme.palette.White
                 }
                 fontColor={
-                  personalityList.includes(value)
+                  personalityList.includes(key)
                     ? theme.palette.White
                     : theme.palette.Black
                 }
                 border={
-                  personalityList.includes(value)
+                  personalityList.includes(key)
                     ? `1px solid ${theme.palette.Black}`
                     : `1px solid ${theme.palette.Gray100}`
                 }
-                onClick={() => handleToggle(value)}
+                onClick={() => handleToggle(key)}
               >
-                {value}
+                {label}
               </Button>
             ))}
           </FitFlex>

--- a/apps/duri/src/components/request/Calendar.tsx
+++ b/apps/duri/src/components/request/Calendar.tsx
@@ -41,7 +41,7 @@ export default MonthlyCalendar;
 
 const CustomCalendarCss = css`
   .react-calendar__tile {
-    height: 55px;
+    height: 45px;
     border-radius: 99px;
     font-size: 15px;
   }

--- a/apps/duri/src/components/request/PetInfo.tsx
+++ b/apps/duri/src/components/request/PetInfo.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   HeightFitFlex,
   Image,
+  ProfileImage,
   Text,
   theme,
 } from '@duri-fe/ui';
@@ -13,7 +14,7 @@ import styled from '@emotion/styled';
 
 interface PetInfoProps {
   name: string,
-  image: string | null,
+  image?: string,
   age: number,
   breed: string,
   gender: string,
@@ -51,12 +52,12 @@ const PetInfo = ({
             </SelectedTag>
             {image ? (
               <Image src={image} borderRadius={8} width={100} height={100} />
-            ) : <>없으면 디폴트 이미지로 들어가게</>}
+            ) : <ProfileImage borderRadius={8} width={100} height={100} />}
           </PetImageWrapper>
           <HeightFitFlex direction="column" gap={12} align="flex-start">
             <Text typo="Body2">{name}</Text>
             <Text typo="Caption2" colorCode={theme.palette.Gray400}>
-              {breed}, {age}, {gender}, {weight}kg
+              {breed}, {gender === 'F' ? '여아' : '남아'}, {age}살, {weight}kg
             </Text>
           </HeightFitFlex>
         </Flex>

--- a/apps/duri/src/pages/Home.tsx
+++ b/apps/duri/src/pages/Home.tsx
@@ -71,7 +71,7 @@ const Home = () => {
           />
           <CarouselHome
             upcomingReservation={upcomingReservation}
-            lastReservation={petData?.lastGrooming ?? null}
+            lastReservation={petData?.lastGrooming}
           />
         </HeightFitFlex>
         {/* 단골 빠른입찰 */}

--- a/apps/duri/src/pages/My/index.tsx
+++ b/apps/duri/src/pages/My/index.tsx
@@ -1,0 +1,44 @@
+import { Card, PetInfo } from '@duri-fe/ui';
+
+const MyPage = () => {
+  const character = ['character3', 'character1', 'character6'];
+  const diseases = ['disease1', 'disease2'];
+  return (
+    <>
+      <Card borderRadius={16} padding='12px 30px 16px 12px'>
+        <PetInfo
+          name="멍뭉이"
+          age={4}
+          breed="시츄"
+          gender="M"
+          weight={3.7}
+          neutering={true}
+        />
+      </Card>
+      <Card borderRadius={16} padding='12px 30px 16px 12px'>
+      <PetInfo
+        name="멍뭉이"
+        age={4}
+        breed="시츄"
+        gender="M"
+        weight={3.7}
+        neutering={false}
+        character={character}
+      /></Card>
+      <Card borderRadius={16} padding='12px 30px 16px 12px'>
+
+      <PetInfo
+        name="멍뭉이"
+        age={4}
+        breed="시츄"
+        gender="M"
+        weight={3.7}
+        neutering={false}
+        character={character}
+        diseases={diseases}
+      /></Card>
+    </>
+  );
+};
+
+export default MyPage;

--- a/apps/duri/src/pages/Request/index.tsx
+++ b/apps/duri/src/pages/Request/index.tsx
@@ -21,7 +21,7 @@ import { useGetPetInfo } from '@duri-fe/utils';
 interface PetInfoType {
   petId: number;
   name: string;
-  imageURL: string | null;
+  imageURL?: string;
   breed: string;
   age: number;
   weight: number;
@@ -29,12 +29,22 @@ interface PetInfoType {
   lastGrooming: string | null;
 }
 
-const timeList = Array(10).fill(0).map((_, i) => `${9 + i}:00`);
+const timeList = Array(10)
+  .fill(0)
+  .map((_, i) => `${9 + i}:00`);
 
 const RequestPage = () => {
   const petData = useGetPetInfo();
   const [requestInfo, setrequestInfo] = useState<RequestType>(defaultRequestInfo);
-  const [petInfo, setPetInfo] = useState<PetInfoType | null>(null);
+  const [requestList, setRequestList] =
+    useState<RequestType>(defaultRequestInfo);
+  const [petInfo, setPetInfo] = useState<PetInfoType | null>({  petId: 1,
+    name: '멍뭉이',
+    breed: '시츄',
+    age: 4,
+    weight: 3.7,
+    gender: 'F',
+    lastGrooming: "2024-12-01"});
   const [isButton, setIsButton] = useState<boolean>(false);
 
   const handleSelect = (
@@ -44,7 +54,7 @@ const RequestPage = () => {
     if (key === 'petId') {
       setrequestInfo((prev) => ({
         ...prev,
-        petId: value === null || typeof value === 'number' ? value : null,  // petId만 undefined일 경우 처리가 필요
+        petId: value === undefined || typeof value === 'number' ? value : undefined, // petId만 undefined일 경우 처리가 필요
       }));
       return;
     }
@@ -59,7 +69,7 @@ const RequestPage = () => {
   useEffect(() => {
     if (petData) {
       setPetInfo(petData);
-      if (petData && petData.petId !== null) {
+      if (petData && petData.petId !== undefined) {
         handleSelect('petId', petData.petId); // id가 null이 아닌 경우만 설정
       }
     }

--- a/apps/duri/src/pages/Request/index.tsx
+++ b/apps/duri/src/pages/Request/index.tsx
@@ -26,7 +26,7 @@ interface PetInfoType {
   age: number;
   weight: number;
   gender: string;
-  lastGrooming: string | null;
+  lastGrooming?: string;
 }
 
 const timeList = Array(10)
@@ -36,8 +36,6 @@ const timeList = Array(10)
 const RequestPage = () => {
   const petData = useGetPetInfo();
   const [requestInfo, setrequestInfo] = useState<RequestType>(defaultRequestInfo);
-  const [requestList, setRequestList] =
-    useState<RequestType>(defaultRequestInfo);
   const [petInfo, setPetInfo] = useState<PetInfoType | null>({  petId: 1,
     name: '멍뭉이',
     breed: '시츄',

--- a/packages/ui/src/components/Quotation/PetInfo.tsx
+++ b/packages/ui/src/components/Quotation/PetInfo.tsx
@@ -1,12 +1,24 @@
-import { Flex, HeightFitFlex, Image, Text, theme } from '@duri-fe/ui';
+import {
+  diseaseMapping,
+  Flex,
+  HeightFitFlex,
+  personalityMapping,
+  ProfileImage,
+  SalonTag,
+  Text,
+  theme,
+} from '@duri-fe/ui';
 
 interface PetInfoType {
-  image: string;
+  image?: string;
   name: string;
   age: number;
   breed: string;
   weight: number;
   gender: string;
+  neutering?: boolean;
+  character?: string[];
+  diseases?: string[];
 }
 
 export const PetInfo = ({
@@ -16,16 +28,50 @@ export const PetInfo = ({
   breed,
   weight,
   gender,
+  neutering,
+  character,
+  diseases,
 }: PetInfoType) => {
   return (
-    <HeightFitFlex gap={18} margin="19px 0 0 0">
-      <Image borderRadius={40} width={133} height={133} src={image} />
-      <Flex direction="column" gap={15} align="flex-start">
-        <Text typo="Body2">{name}</Text>
-        <Text typo="Caption2" colorCode={theme.palette.Gray400}>
-          {breed}, {gender === 'F' ? '암컷' : '수컷'}, {age}세, {weight}kg
-        </Text>
+    <Flex direction="column" gap={16}>
+      <HeightFitFlex gap={18} margin="19px 0 0 0">
+        <ProfileImage borderRadius={40} width={133} height={133} src={image} />
+        <Flex direction="column" gap={15} align="flex-start">
+          <Text typo="Body2">{name}</Text>
+          <Text typo="Caption2" colorCode={theme.palette.Gray400}>
+            {breed}, {gender === 'F' ? '암컷' : '수컷'}, {age}세, {weight}kg
+          </Text>
+          {neutering && <SalonTag content="중성화 완료" />}
+        </Flex>
+      </HeightFitFlex>
+      <Flex justify="flex-start" gap={4}>
+        {character &&
+          character.map((key, index) => {
+            const label = personalityMapping[key]
+            return <SalonTag
+              key={index}
+              height={23}
+              content={label}
+              bg={theme.palette.Normal100}
+              colorCode={theme.palette.Normal700}
+              typo="Label2"
+            />
+          })}
       </Flex>
-    </HeightFitFlex>
+      <Flex justify="flex-start" gap={4}>
+        {diseases &&
+          diseases.map((key, index) => {
+            const label = diseaseMapping[key]
+            return <SalonTag
+              key={index}
+              height={23}
+              content={label}
+              bg={theme.palette.Alert}
+              colorCode={theme.palette.White}
+              typo="Label2"
+            />
+})}
+      </Flex>
+    </Flex>
   );
 };

--- a/packages/ui/src/components/Quotation/index.tsx
+++ b/packages/ui/src/components/Quotation/index.tsx
@@ -1,3 +1,4 @@
 export * from './RequestQuotation';
 export * from './ResponseQuotation';
 export * from './Timetable';
+export * from './PetInfo';

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -1,11 +1,14 @@
-import { Text, theme } from '@duri-fe/ui';
+import { Text, theme, TypeOfTypo } from '@duri-fe/ui';
 
 import { WidthFitFlex } from '../FlexBox';
 
 /**
  * @param {string} bg: 태그의 배경색
+ * @param {string} colorCode: 태그의 글자색
  * @param {number} borderRadius: 태그의 border radius
  * @param {string} content: 태그의 내용
+ * @param {number} height: 태그의 높이
+ * @param {string} typo: 태그의 typo
  */
 
 interface TagProps {
@@ -13,17 +16,27 @@ interface TagProps {
   bg?: string;
   borderRadius?: number;
   height?: number;
+  typo?: keyof TypeOfTypo;
+  colorCode?: string;
 }
 
-export const SalonTag = ({ content, bg, borderRadius, height }: TagProps) => {
+export const SalonTag = ({
+  content,
+  bg,
+  borderRadius,
+  height,
+  colorCode = theme.palette.Gray500,
+  typo = 'Caption5',
+}: TagProps) => {
   return (
     <WidthFitFlex
       backgroundColor={bg ?? theme.palette.Gray50}
       borderRadius={borderRadius ?? 2}
       padding="5.5px 4px"
       height={height ?? 20}
+      width={height ?? 20}
     >
-      <Text typo="Caption5" colorCode={theme.palette.Gray500}>
+      <Text typo={typo} colorCode={colorCode}>
         {content}
       </Text>
     </WidthFitFlex>

--- a/packages/ui/src/data/index.ts
+++ b/packages/ui/src/data/index.ts
@@ -1,1 +1,2 @@
 export * from './quotation';
+export * from './pet';

--- a/packages/ui/src/data/pet.ts
+++ b/packages/ui/src/data/pet.ts
@@ -1,0 +1,18 @@
+// 성격 목록
+export const personalityMapping: { [key: string]: string } = {
+  character1: '예민해요' ,
+  character2: '낯가려요' ,
+  character3: '입질이 있어요' ,
+  character4: '사람을 좋아해요' ,
+  character5: '얌전해요' ,
+  character6: '낯선 손길은 무서워요',
+};
+
+//질환 목록
+export const diseaseMapping: { [key: string]: string } = {
+  disease1: '피부 질환',
+  disease2: '귀 염증',
+  disease3: '관절 질환',
+  disease4: '기저 질환',
+  disease5: '딱히 없어요',
+};

--- a/packages/utils/src/apis/duri/home.ts
+++ b/packages/utils/src/apis/duri/home.ts
@@ -1,5 +1,16 @@
 import { duriInstance } from '../axiosConfig';
-import { PetInfoResponse, RecommendShopResponse, RegularShopResponse, UpcomingReservationResponse } from '../types';
+import { BaseResponse, PetInfoResponse, RecommendShopResponse, RegularShopResponse, UpcomingReservationResponse } from '../types';
+interface PetInfoResponse extends BaseResponse {
+  response: {
+    petId: number;
+    name: string;
+    image?: string;
+    breed: string;
+    age: number;
+    weight: number;
+    gender: string;
+    lastGrooming: string | null;
+  };
 
 export const getRegularShopInfo = async(): Promise<RegularShopResponse['response']> => {
   const response = await duriInstance.get(`home/regular/1`);

--- a/packages/utils/src/apis/duri/home.ts
+++ b/packages/utils/src/apis/duri/home.ts
@@ -1,16 +1,17 @@
 import { duriInstance } from '../axiosConfig';
-import { BaseResponse, PetInfoResponse, RecommendShopResponse, RegularShopResponse, UpcomingReservationResponse } from '../types';
+import { BaseResponse, RecommendShopResponse, RegularShopResponse, UpcomingReservationResponse } from '../types';
 interface PetInfoResponse extends BaseResponse {
   response: {
     petId: number;
     name: string;
-    image?: string;
+    imageURL?: string;
     breed: string;
     age: number;
     weight: number;
     gender: string;
-    lastGrooming: string | null;
+    lastGrooming?: string;
   };
+}
 
 export const getRegularShopInfo = async(): Promise<RegularShopResponse['response']> => {
   const response = await duriInstance.get(`home/regular/1`);


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-82

## PR 개요

- SalonTag Typo Props 추가
- 성격/질환 key - label 설정
   - 이에 따른 key mapping 코드 추가!!!
- Card안에 들어갈 반려견 정보 컴포넌트 구현
   - PetInfo 컴포넌트가 duri에도 있고 packages/ui에도 있는데 요건 공통 버전입니닷
   - Props: name, age, breed, gender, weight, neutering, character, diseases


## Screenshots
<img width="357" alt="image" src="https://github.com/user-attachments/assets/3eec2f81-ee5c-4b5a-8673-340ea08bf6d5">

