### PR TITLE
[feat] 미용사 견적/예약/시술 조회 구현

### DIFF
--- a/apps/salon/package.json
+++ b/apps/salon/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/apps/salon/src/App.tsx
+++ b/apps/salon/src/App.tsx
@@ -11,6 +11,7 @@ import OnboardingPage from '@pages/Onboarding';
 import StartPage from '@pages/Onboarding/StartPage';
 import QuotationPage from '@pages/Quotation';
 import ReplyPage from '@pages/Quotation/ReplyPage';
+import ReservationPage from '@pages/Quotation/ReservationPage';
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
         <Route path="/onboarding/detail" element={<OnboardingPage />} />
 
         <Route path="/quotation" element={<QuotationPage />} />
+        <Route path="/quotation/reservation" element={<ReservationPage />} />
         <Route path="/quotation/reply/:requestId" element={<ReplyPage />} />
       </Routes>
     </BrowserRouter>

--- a/apps/salon/src/components/quotation/DetailQuotation.tsx
+++ b/apps/salon/src/components/quotation/DetailQuotation.tsx
@@ -1,4 +1,4 @@
-// import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Button, Flex, HeightFitFlex, ResponseQuotation, Text, theme } from "@duri-fe/ui";
 import { useGetDetailQuotation } from "@duri-fe/utils";
@@ -15,15 +15,20 @@ export const DetailQuotation = ({
   enableCompleteButton = false,
   closeModal,
 }: DetailQuotationProps) => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
 
   const { data: quotation } = useGetDetailQuotation(requestId);
+
+  const handleNavigate = () => {
+    closeModal();
+    navigate(`/feedback`);
+  }
 
   if (!quotation) return null;
 
   return (
     <Flex direction="column">
-      <ResponseQuotation responseList={quotation}>
+      <ResponseQuotation responseList={quotation} isSalon>
         <HeightFitFlex gap={8}>
           <Button 
             width='120px'
@@ -40,11 +45,7 @@ export const DetailQuotation = ({
             fontColor={theme.palette.White}
             disabled={!enableCompleteButton}
             borderRadius="8px"
-            // onClick={
-            //   completeToggle
-            //     ? handleCompleteGrooming
-            //     : bottomSheetProps.onDismiss
-            // }
+            onClick={enableCompleteButton ? handleNavigate : undefined}
           >
             <Text typo='Body3'>일지 쓰기</Text>
           </CompleteButton>

--- a/apps/salon/src/components/quotation/DetailQuotation.tsx
+++ b/apps/salon/src/components/quotation/DetailQuotation.tsx
@@ -1,0 +1,59 @@
+// import { useNavigate } from "react-router-dom";
+
+import { Button, Flex, HeightFitFlex, ResponseQuotation, Text, theme } from "@duri-fe/ui";
+import { useGetDetailQuotation } from "@duri-fe/utils";
+import styled from "@emotion/styled";
+
+interface DetailQuotationProps {
+  requestId: number;
+  enableCompleteButton?: boolean;
+  closeModal: () => void;
+}
+
+export const DetailQuotation = ({
+  requestId,
+  enableCompleteButton = false,
+  closeModal,
+}: DetailQuotationProps) => {
+  // const navigate = useNavigate();
+
+  const { data: quotation } = useGetDetailQuotation(requestId);
+
+  if (!quotation) return null;
+
+  return (
+    <Flex direction="column">
+      <ResponseQuotation responseList={quotation}>
+        <HeightFitFlex gap={8}>
+          <Button 
+            width='120px'
+            height='47px'
+            bg={theme.palette.Gray20}
+            borderRadius='8px'
+            onClick={closeModal}
+          >
+            <Text typo='Body3'>나중에 쓰기</Text>
+          </Button>
+          <CompleteButton 
+            height="47px"
+            bg={enableCompleteButton ? theme.palette.Black : theme.palette.Gray200}
+            fontColor={theme.palette.White}
+            disabled={!enableCompleteButton}
+            borderRadius="8px"
+            // onClick={
+            //   completeToggle
+            //     ? handleCompleteGrooming
+            //     : bottomSheetProps.onDismiss
+            // }
+          >
+            <Text typo='Body3'>일지 쓰기</Text>
+          </CompleteButton>
+        </HeightFitFlex>
+      </ResponseQuotation>
+    </Flex>
+  );
+}
+
+const CompleteButton = styled(Button)`
+  flex-shrink: 1;
+`

--- a/apps/salon/src/components/quotation/DetailQuotation.tsx
+++ b/apps/salon/src/components/quotation/DetailQuotation.tsx
@@ -1,8 +1,15 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from 'react-router-dom';
 
-import { Button, Flex, HeightFitFlex, ResponseQuotation, Text, theme } from "@duri-fe/ui";
-import { useGetDetailQuotation } from "@duri-fe/utils";
-import styled from "@emotion/styled";
+import {
+  Button,
+  Flex,
+  HeightFitFlex,
+  ResponseQuotation,
+  Text,
+  theme,
+} from '@duri-fe/ui';
+import { useGetDetailQuotation } from '@duri-fe/utils';
+import styled from '@emotion/styled';
 
 interface DetailQuotationProps {
   requestId: number;
@@ -22,39 +29,43 @@ export const DetailQuotation = ({
   const handleNavigate = () => {
     closeModal();
     navigate(`/feedback`);
-  }
+  };
 
-  if (!quotation) return null;
+  if (!quotation) {
+    return null;
+  }
 
   return (
     <Flex direction="column">
       <ResponseQuotation responseList={quotation} isSalon>
         <HeightFitFlex gap={8}>
-          <Button 
-            width='120px'
-            height='47px'
+          <Button
+            width="120px"
+            height="47px"
             bg={theme.palette.Gray20}
-            borderRadius='8px'
+            borderRadius="8px"
             onClick={closeModal}
           >
-            <Text typo='Body3'>나중에 쓰기</Text>
+            <Text typo="Body3">나중에 쓰기</Text>
           </Button>
-          <CompleteButton 
+          <CompleteButton
             height="47px"
-            bg={enableCompleteButton ? theme.palette.Black : theme.palette.Gray200}
+            bg={
+              enableCompleteButton ? theme.palette.Black : theme.palette.Gray200
+            }
             fontColor={theme.palette.White}
             disabled={!enableCompleteButton}
             borderRadius="8px"
             onClick={enableCompleteButton ? handleNavigate : undefined}
           >
-            <Text typo='Body3'>일지 쓰기</Text>
+            <Text typo="Body3">일지 쓰기</Text>
           </CompleteButton>
         </HeightFitFlex>
       </ResponseQuotation>
     </Flex>
   );
-}
+};
 
 const CompleteButton = styled(Button)`
   flex-shrink: 1;
-`
+`;

--- a/apps/salon/src/components/quotation/TabBarItem.tsx
+++ b/apps/salon/src/components/quotation/TabBarItem.tsx
@@ -6,6 +6,7 @@ interface TabBarItemProps {
   selected: boolean;
   typo?: KeyOfTypo;
   fitContent?: boolean;
+  onClick?: () => void;
 }
 
 export const TabBarItem = ({
@@ -13,9 +14,10 @@ export const TabBarItem = ({
   selected,
   typo = 'Body1',
   fitContent = false,
+  onClick,
 }: TabBarItemProps) => {
   return (
-    <Wrapper selected={selected} fitContent={fitContent}>
+    <Wrapper selected={selected} fitContent={fitContent} onClick={onClick}>
       <Text typo={typo} colorCode={selected ? theme.palette.Black : theme.palette.Gray300}>{label}</Text>
     </Wrapper>
   )

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -2,230 +2,196 @@ import { BASE_URL } from '@duri-fe/utils';
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  http.get(BASE_URL+'/quotation/request/new', () => {
-    return HttpResponse.json(
-      {
-        "success": true,
-        "response": [
-          {
-            "requestId": 2,
-            "userId": 2,
-            "petId": 2,
-            "petImage": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
-            "petName": "초코",
-            "petAge": 3,
-            "petGender": "F",
-            "petBreed": "푸들",
-            "petWeight": 10,
-            "petNeutering": true,
-            "petCharacter": [
-              "string"
-            ],
-            "petDiseases": [
-              "string"
-            ],
-            "totalPrice": 0,
-            "status": "string"
-          }
-        ],
-        "error": {
-          "message": "string",
-          "status": 0
-        }
-      }
-    )
-  }),
-
-  http.get(BASE_URL+'/quotation/request/approved', () => {
-    return HttpResponse.json(
-      {
-        "success": true,
-        "response": [
-          {
-            "requestId": 2,
-            "userId": 2,
-            "petId": 2,
-            "petImage": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
-            "petName": "초코",
-            "petAge": 3,
-            "petGender": "F",
-            "petBreed": "푸들",
-            "petWeight": 10,
-            "petNeutering": true,
-            "petCharacter": [
-              "string"
-            ],
-            "petDiseases": [
-              "string"
-            ],
-            "totalPrice": 0,
-            "status": "string"
-          }
-        ],
-        "error": {
-          "message": "string",
-          "status": 0
-        }
-      }
-    );
-  }),
-
-  http.get(BASE_URL+'/quotation/request/reservation', () => {
-    return HttpResponse.json(
-      {
-        "success": true,
-        "response": [
-          {
-            "requestId": 2,
-            "userId": 2,
-            "petId": 2,
-            "petDetailResponse": {
-              "image": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
-              "name": "초코",
-              "age": 3,
-              "gender": "F",
-              "breed": "푸들",
-              "weight": 10,
-              "neutering": true,
-              "character": [
-                "사람을 잘 따름",
-                "조용한 성격"
-              ],
-              "diseases": [
-                "딱히 없음"
-              ],
-              "lastGrooming": "2023-10-14T15:00:00.000+00:00"
-            },
-            "groomerName": "한지민",
-            "groomerImage": "https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__",
-            "totalPrice": 220,
-            "dday": 0,
-            "date": "2024-12-07",
-            "startTime": "2024-12-12T06:53:16.989Z",
-            "endTime": "2024-12-12T06:53:16.989Z"
-          }
-        ],
-        "error": null
-      }
-    )
-  }),
-
-  http.get(BASE_URL+'/quotation/request/reservation/complete', () => {
-    return HttpResponse.json(
-      {
-        "success": true,
-        "response": [
-          {
-            "requestId": 2,
-            "userId": 2,
-            "petId": 2,
-            "petDetailResponse": {
-              "image": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
-              "name": "초코",
-              "age": 3,
-              "gender": "F",
-              "breed": "푸들",
-              "weight": 10,
-              "neutering": true,
-              "character": [
-                "사람을 잘 따름",
-                "조용한 성격"
-              ],
-              "diseases": [
-                "딱히 없음"
-              ],
-              "lastGrooming": "2023-10-14T15:00:00.000+00:00"
-            },
-            "groomerName": "한지민",
-            "groomerImage": "https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__",
-            "totalPrice": 220,
-            "dday": 0,
-            "date": "2024-12-07",
-            "startTime": "2024-12-12T06:53:16.989Z",
-            "endTime": "2024-12-12T06:53:16.989Z"
-          }
-        ],
-        "error": {
-          "message": "string",
-          "status": 0
-        }
-      }
-    )
-  }),
-
-  http.get(BASE_URL+'/quotation/2', () => {
-    return HttpResponse.json(
-      {
-        "success": true,
-        "response": {
-          "shopDetail": {
-            "shopName": "강남 미용샵",
-            "shopAddress": "서울시 강남구",
-            "shopPhone": "02-123-4567",
-            "groomerName": "한지민"
-          },
-          "quotationCreatedAt": "2024-12-07T09:31:48.965428",
-          "petDetail": {
-            "image": "https://example.com/dog2.jpg",
-            "name": "초코",
-            "age": 3,
-            "gender": "F",
-            "breed": "푸들",
-            "weight": 10,
-            "neutering": true,
-            "character": [
-              "사람을 잘 따름",
-              "조용한 성격"
-            ],
-            "diseases": [
-              "딱히 없음"
-            ],
-            "lastGrooming": "2023-10-14T15:00:00.000+00:00"
-          },
-          "menuDetail": {
-            "groomingMenu": [
-              "string"
-            ],
-            "additionalGrooming": [
-              "stringaa"
-            ],
-            "specialCare": [
-              "stringaa"
-            ],
-            "designCut": [
-              "stringaa"
-            ],
-            "otherRequests": "stringaaa",
-            "day": "2024-12-06",
-            "time9": false,
-            "time10": false,
-            "time11": false,
-            "time12": false,
-            "time13": true,
-            "time14": true,
-            "time15": true,
-            "time16": true,
-            "time17": false,
-            "time18": false
-          },
-          "quotation": {
-            "requestId": 2,
-            "priceDetail": {
-              "groomingPrice": 220,
-              "additionalPrice": 220,
-              "specialCarePrice": 220,
-              "designPrice": 220,
-              "customPrice": 220,
-              "totalPrice": 220
-            },
-            "memo": "2222string",
-            "startDateTime": "2024-12-07T00:31:30.495",
-            "endDateTime": "2024-12-07T00:31:30.495"
-          },
-          "status": "결제 완료"
+  http.get(BASE_URL + '/quotation/request/new', () => {
+    return HttpResponse.json({
+      success: true,
+      response: [
+        {
+          requestId: 2,
+          userId: 2,
+          petId: 2,
+          petImage:
+            'https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__',
+          petName: '초코',
+          petAge: 3,
+          petGender: 'F',
+          petBreed: '푸들',
+          petWeight: 10,
+          petNeutering: true,
+          petCharacter: ['string'],
+          petDiseases: ['string'],
+          totalPrice: 0,
+          status: 'string',
         },
-        "error": null
-      }
-    )
+      ],
+      error: {
+        message: 'string',
+        status: 0,
+      },
+    });
+  }),
+
+  http.get(BASE_URL + '/quotation/request/approved', () => {
+    return HttpResponse.json({
+      success: true,
+      response: [
+        {
+          requestId: 2,
+          userId: 2,
+          petId: 2,
+          petImage:
+            'https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__',
+          petName: '초코',
+          petAge: 3,
+          petGender: 'F',
+          petBreed: '푸들',
+          petWeight: 10,
+          petNeutering: true,
+          petCharacter: ['string'],
+          petDiseases: ['string'],
+          totalPrice: 0,
+          status: 'string',
+          requestCreatedAt: '2024-12-07T09:31:48.965428',
+        },
+      ],
+      error: {
+        message: 'string',
+        status: 0,
+      },
+    });
+  }),
+
+  http.get(BASE_URL + '/quotation/request/reservation', () => {
+    return HttpResponse.json({
+      success: true,
+      response: [
+        {
+          requestId: 2,
+          userId: 2,
+          petId: 2,
+          petDetailResponse: {
+            image:
+              'https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__',
+            name: '초코',
+            age: 3,
+            gender: 'F',
+            breed: '푸들',
+            weight: 10,
+            neutering: true,
+            character: ['사람을 잘 따름', '조용한 성격'],
+            diseases: ['딱히 없음'],
+            lastGrooming: '2023-10-14T15:00:00.000+00:00',
+          },
+          groomerName: '한지민',
+          groomerImage:
+            'https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__',
+          totalPrice: 220,
+          dday: 0,
+          date: '2024-12-07',
+          startTime: '2024-12-12T06:53:16.989Z',
+          endTime: '2024-12-12T06:53:16.989Z',
+        },
+      ],
+      error: null,
+    });
+  }),
+
+  http.get(BASE_URL + '/quotation/request/reservation/complete', () => {
+    return HttpResponse.json({
+      success: true,
+      response: [
+        {
+          requestId: 2,
+          userId: 2,
+          petId: 2,
+          petDetailResponse: {
+            image:
+              'https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__',
+            name: '초코',
+            age: 3,
+            gender: 'F',
+            breed: '푸들',
+            weight: 10,
+            neutering: true,
+            character: ['사람을 잘 따름', '조용한 성격'],
+            diseases: ['딱히 없음'],
+            lastGrooming: '2023-10-14T15:00:00.000+00:00',
+          },
+          groomerName: '한지민',
+          groomerImage:
+            'https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__',
+          totalPrice: 220,
+          dday: 0,
+          date: '2024-12-07',
+          startTime: '2024-12-12T06:53:16.989Z',
+          endTime: '2024-12-12T06:53:16.989Z',
+        },
+      ],
+      error: {
+        message: 'string',
+        status: 0,
+      },
+    });
+  }),
+
+  http.get(BASE_URL + '/quotation/2', () => {
+    return HttpResponse.json({
+      success: true,
+      response: {
+        shopDetail: {
+          shopName: '강남 미용샵',
+          shopAddress: '서울시 강남구',
+          shopPhone: '02-123-4567',
+          groomerName: '한지민',
+        },
+        quotationCreatedAt: '2024-12-07T09:31:48.965428',
+        petDetail: {
+          image: 'https://example.com/dog2.jpg',
+          name: '초코',
+          age: 3,
+          gender: 'F',
+          breed: '푸들',
+          weight: 10,
+          neutering: true,
+          character: ['사람을 잘 따름', '조용한 성격'],
+          diseases: ['딱히 없음'],
+          lastGrooming: '2023-10-14T15:00:00.000+00:00',
+        },
+        menuDetail: {
+          groomingMenu: ['string'],
+          additionalGrooming: ['stringaa'],
+          specialCare: ['stringaa'],
+          designCut: ['stringaa'],
+          otherRequests: 'stringaaa',
+          day: '2024-12-06',
+          time9: false,
+          time10: false,
+          time11: false,
+          time12: false,
+          time13: true,
+          time14: true,
+          time15: true,
+          time16: true,
+          time17: false,
+          time18: false,
+        },
+        quotation: {
+          requestId: 2,
+          priceDetail: {
+            groomingPrice: 220,
+            additionalPrice: 220,
+            specialCarePrice: 220,
+            designPrice: 220,
+            customPrice: 220,
+            totalPrice: 220,
+          },
+          memo: '2222string',
+          startDateTime: '2024-12-07T00:31:30.495',
+          endDateTime: '2024-12-07T00:31:30.495',
+        },
+        status: '결제 완료',
+      },
+      error: null,
+    });
   }),
 ];

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -152,4 +152,80 @@ export const handlers = [
       }
     )
   }),
+
+  http.get(BASE_URL+'/quotation/request/reservation/complete', () => {
+    return HttpResponse.json(
+      {
+        "success": true,
+        "response": {
+          "shopDetail": {
+            "shopName": "강남 미용샵",
+            "shopAddress": "서울시 강남구",
+            "shopPhone": "02-123-4567",
+            "groomerName": "한지민"
+          },
+          "quotationCreatedAt": "2024-12-07T09:31:48.965428",
+          "petDetail": {
+            "image": "https://example.com/dog2.jpg",
+            "name": "초코",
+            "age": 3,
+            "gender": "F",
+            "breed": "푸들",
+            "weight": 10,
+            "neutering": true,
+            "character": [
+              "사람을 잘 따름",
+              "조용한 성격"
+            ],
+            "diseases": [
+              "딱히 없음"
+            ],
+            "lastGrooming": "2023-10-14T15:00:00.000+00:00"
+          },
+          "menuDetail": {
+            "groomingMenu": [
+              "string"
+            ],
+            "additionalGrooming": [
+              "stringaa"
+            ],
+            "specialCare": [
+              "stringaa"
+            ],
+            "designCut": [
+              "stringaa"
+            ],
+            "otherRequests": "stringaaa",
+            "day": "2024-12-06",
+            "time9": false,
+            "time10": false,
+            "time11": false,
+            "time12": false,
+            "time13": true,
+            "time14": true,
+            "time15": true,
+            "time16": true,
+            "time17": false,
+            "time18": false
+          },
+          "quotation": {
+            "requestId": 2,
+            "priceDetail": {
+              "groomingPrice": 220,
+              "additionalPrice": 220,
+              "specialCarePrice": 220,
+              "designPrice": 220,
+              "customPrice": 220,
+              "totalPrice": 220
+            },
+            "memo": "2222string",
+            "startDateTime": "2024-12-07T00:31:30.495",
+            "endDateTime": "2024-12-07T00:31:30.495"
+          },
+          "status": "결제 완료"
+        },
+        "error": null
+      }
+    )
+  }),
 ];

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -45,7 +45,7 @@ export const handlers = [
             "userId": 2,
             "petId": 2,
             "petDetailResponse": {
-              "image": "https://example.com/dog2.jpg",
+              "image": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
               "name": "초코",
               "age": 3,
               "gender": "F",
@@ -62,12 +62,12 @@ export const handlers = [
               "lastGrooming": "2023-10-14T15:00:00.000+00:00"
             },
             "groomerName": "한지민",
-            "groomerImage": "https://example.com/groomer1.jpg",
+            "groomerImage": "https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__",
             "totalPrice": 220,
             "dday": 0,
             "date": "2024-12-07",
-            "startTime": "00:31:30",
-            "endTime": "00:31:30"
+            "startTime": "2024-12-12T06:53:16.989Z",
+            "endTime": "2024-12-12T06:53:16.989Z"
           }
         ],
         "error": null

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -1,11 +1,37 @@
+import { BASE_URL } from '@duri-fe/utils';
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  http.get('https://api.example.com/api/user', () => {
-    return HttpResponse.json({
-      id: 'c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d',
-      firstName: 'John',
-      lastName: 'Maverick',
-    });
+  http.get(BASE_URL+'/quotation/request/approved', () => {
+    return HttpResponse.json(
+      {
+        "success": true,
+        "response": [
+          {
+            "requestId": 0,
+            "userId": 0,
+            "petId": 0,
+            "petImage": "string",
+            "petName": "string",
+            "petAge": 0,
+            "petBreed": "string",
+            "petWeight": 0,
+            "petNeutering": true,
+            "petCharacter": [
+              "string"
+            ],
+            "petDiseases": [
+              "string"
+            ],
+            "totalPrice": 0,
+            "status": "string"
+          }
+        ],
+        "error": {
+          "message": "string",
+          "status": 0
+        }
+      }
+    );
   }),
 ];

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -34,4 +34,44 @@ export const handlers = [
       }
     );
   }),
+
+  http.get(BASE_URL+'/quotation/request/reservation', () => {
+    return HttpResponse.json(
+      {
+        "success": true,
+        "response": [
+          {
+            "requestId": 2,
+            "userId": 2,
+            "petId": 2,
+            "petDetailResponse": {
+              "image": "https://example.com/dog2.jpg",
+              "name": "초코",
+              "age": 3,
+              "gender": "F",
+              "breed": "푸들",
+              "weight": 10,
+              "neutering": true,
+              "character": [
+                "사람을 잘 따름",
+                "조용한 성격"
+              ],
+              "diseases": [
+                "딱히 없음"
+              ],
+              "lastGrooming": "2023-10-14T15:00:00.000+00:00"
+            },
+            "groomerName": "한지민",
+            "groomerImage": "https://example.com/groomer1.jpg",
+            "totalPrice": 220,
+            "dday": 0,
+            "date": "2024-12-07",
+            "startTime": "00:31:30",
+            "endTime": "00:31:30"
+          }
+        ],
+        "error": null
+      }
+    )
+  })
 ];

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -153,7 +153,7 @@ export const handlers = [
     )
   }),
 
-  http.get(BASE_URL+'/quotation/request/reservation/complete', () => {
+  http.get(BASE_URL+'/quotation/2', () => {
     return HttpResponse.json(
       {
         "success": true,

--- a/apps/salon/src/mocks/handler.ts
+++ b/apps/salon/src/mocks/handler.ts
@@ -2,20 +2,55 @@ import { BASE_URL } from '@duri-fe/utils';
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
+  http.get(BASE_URL+'/quotation/request/new', () => {
+    return HttpResponse.json(
+      {
+        "success": true,
+        "response": [
+          {
+            "requestId": 2,
+            "userId": 2,
+            "petId": 2,
+            "petImage": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
+            "petName": "초코",
+            "petAge": 3,
+            "petGender": "F",
+            "petBreed": "푸들",
+            "petWeight": 10,
+            "petNeutering": true,
+            "petCharacter": [
+              "string"
+            ],
+            "petDiseases": [
+              "string"
+            ],
+            "totalPrice": 0,
+            "status": "string"
+          }
+        ],
+        "error": {
+          "message": "string",
+          "status": 0
+        }
+      }
+    )
+  }),
+
   http.get(BASE_URL+'/quotation/request/approved', () => {
     return HttpResponse.json(
       {
         "success": true,
         "response": [
           {
-            "requestId": 0,
-            "userId": 0,
-            "petId": 0,
-            "petImage": "string",
-            "petName": "string",
-            "petAge": 0,
-            "petBreed": "string",
-            "petWeight": 0,
+            "requestId": 2,
+            "userId": 2,
+            "petId": 2,
+            "petImage": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
+            "petName": "초코",
+            "petAge": 3,
+            "petGender": "F",
+            "petBreed": "푸들",
+            "petWeight": 10,
             "petNeutering": true,
             "petCharacter": [
               "string"
@@ -73,5 +108,48 @@ export const handlers = [
         "error": null
       }
     )
-  })
+  }),
+
+  http.get(BASE_URL+'/quotation/request/reservation/complete', () => {
+    return HttpResponse.json(
+      {
+        "success": true,
+        "response": [
+          {
+            "requestId": 2,
+            "userId": 2,
+            "petId": 2,
+            "petDetailResponse": {
+              "image": "https://s3-alpha-sig.figma.com/img/8c29/fc5b/55e75730409ed6ff39b368807143b832?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=flUI1B-Bl~5cwqSYAgqYroBEts6ZN4Aa4zT0Nm91CHF0RsdVBLPESYMk~JviN3gbPl0ameQj8IEh5GiloS~6AtuxIhsQpWxEewYe~BrjtcHGpO0NU4Vq5HcWgI0v~o1NvS6dXNkLqVh~nxvf807K~ufbnaSOg6Du4IFzEbxmhAQS~Peb3I2~zn-g5yoRpFKkEwIbaaYr3NdGQ8XCgB~7j0Qb9yeTnYjrj25EjaO~QBumJ-aztNLkdj2Hw228~8GueNT9ttrI884wIeetJe36TXFknK-d8cjxrEdk3DPF8pqFYcuLNmztrPVNH0wUOqySp6MF~8cxRlEPJoKvLB3IiQ__",
+              "name": "초코",
+              "age": 3,
+              "gender": "F",
+              "breed": "푸들",
+              "weight": 10,
+              "neutering": true,
+              "character": [
+                "사람을 잘 따름",
+                "조용한 성격"
+              ],
+              "diseases": [
+                "딱히 없음"
+              ],
+              "lastGrooming": "2023-10-14T15:00:00.000+00:00"
+            },
+            "groomerName": "한지민",
+            "groomerImage": "https://s3-alpha-sig.figma.com/img/f20d/81d2/49c56662ac9bb09ec774324f866934de?Expires=1734912000&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=AgiZSnY6SflgT2CFcJNQF5jYXiDfc68oxS1ywO3JOBgKaVo9fCC94iVxi3G1kKGPxxErBv~xg0dov5JS97OAC0Q7XeAboylEXD0WcQypOOrqnAHsezCHutMDk-wWK1BylcTziztuOVOnL6v4Xu00LjNCpm5Sgogqto-bxs6p-jkq4UkKDWf5IWuh096Jn2W4ypOKQEXBnDGGkp57z5pvHWyWH9nROJS8xv0ORsbtyt-QUXbBGzIZ53i-~lfemuQm5wyAUh72xn5F0WwQv687glBwZXZ6KsDOVCee~SW1Wvito6Kn~96PXVtDsbZRWADP3tadWT3hv2DcAqUt7Aeb~Q__",
+            "totalPrice": 220,
+            "dday": 0,
+            "date": "2024-12-07",
+            "startTime": "2024-12-12T06:53:16.989Z",
+            "endTime": "2024-12-12T06:53:16.989Z"
+          }
+        ],
+        "error": {
+          "message": "string",
+          "status": 0
+        }
+      }
+    )
+  }),
 ];

--- a/apps/salon/src/pages/Quotation/ReplyPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReplyPage.tsx
@@ -1,13 +1,32 @@
-import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
-import { Button, Card, CheckCircle, Flex, FrontBtn, Header, HeightFitFlex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme, WidthFitFlex } from "@duri-fe/ui";
-import { useGetDetailRequest, useModal, usePostQuotation } from "@duri-fe/utils";
-import { defaultQuotationFormData } from "@salon/assets/data/quotation";
-import { QuotationFormData } from "@salon/assets/types/quotation";
-import ReplyForm from "@salon/components/quotation/ReplyForm";
-import ReplyFormDetail from "@salon/components/quotation/ReplyFormDetail";
-import StepTag from "@salon/components/quotation/StepTag";
+import {
+  Button,
+  Card,
+  CheckCircle,
+  Flex,
+  FrontBtn,
+  Header,
+  HeightFitFlex,
+  MobileLayout,
+  Modal,
+  PetInfo,
+  SalonNavbar,
+  Text,
+  theme,
+  WidthFitFlex,
+} from '@duri-fe/ui';
+import {
+  useGetDetailRequest,
+  useModal,
+  usePostQuotation,
+} from '@duri-fe/utils';
+import { defaultQuotationFormData } from '@salon/assets/data/quotation';
+import { QuotationFormData } from '@salon/assets/types/quotation';
+import ReplyForm from '@salon/components/quotation/ReplyForm';
+import ReplyFormDetail from '@salon/components/quotation/ReplyFormDetail';
+import StepTag from '@salon/components/quotation/StepTag';
 
 const ReplyPage = () => {
   const navigate = useNavigate();
@@ -21,7 +40,8 @@ const ReplyPage = () => {
   const [isValid, setIsValid] = useState<boolean>(false);
 
   const { data: request, timeList } = useGetDetailRequest(requestId);
-  const { mutateAsync: submitQuotation, error: postQuotationError } = usePostQuotation();
+  const { mutateAsync: submitQuotation, error: postQuotationError } =
+    usePostQuotation();
 
   const { isOpenModal, openModal, closeModal } = useModal();
 
@@ -37,7 +57,7 @@ const ReplyPage = () => {
   const handleSubmit = async () => {
     console.log(formData);
     await submitQuotation(formData);
-    
+
     if (postQuotationError) {
       console.error(postQuotationError);
       return;
@@ -49,67 +69,115 @@ const ReplyPage = () => {
   const onCloseModal = () => {
     closeModal();
     navigate('/');
-  }
+  };
 
   if (!requestId) return null;
 
   return (
     <MobileLayout backgroundColor={theme.palette.Gray_White}>
-      <Header backIcon title="요청서 보기" titleAlign="start" backgroundColor={theme.palette.White} onClickBack={() => navigate(-1)}/>
-      
+      <Header
+        backIcon
+        title="요청서 보기"
+        titleAlign="start"
+        backgroundColor={theme.palette.White}
+        onClickBack={() => navigate(-1)}
+      />
+
       <Flex direction="column" gap={2}>
         {/** 펫 정보 */}
-        <HeightFitFlex padding="14px 20px"  backgroundColor={theme.palette.White}>
+        <HeightFitFlex
+          padding="14px 20px"
+          backgroundColor={theme.palette.White}
+        >
           <Card height="235" borderRadius={16} padding="12px 16px">
-            {request && <PetInfo 
-              themeVariant="spacious"
-              image={request.pet.image}
-              name={request.pet.name}
-              breed={request.pet.breed}
-              age={request.pet.age}
-              weight={request.pet.weight}
-              gender={request.pet.gender}
-              neutering={request.pet.neutering}
-              character={request.pet.character}
-              diseases={request.pet.diseases}
-            /> }
+            {request && (
+              <PetInfo
+                themeVariant="spacious"
+                image={request.pet.image}
+                name={request.pet.name}
+                breed={request.pet.breed}
+                age={request.pet.age}
+                weight={request.pet.weight}
+                gender={request.pet.gender}
+                neutering={request.pet.neutering}
+                character={request.pet.character}
+                diseases={request.pet.diseases}
+              />
+            )}
           </Card>
         </HeightFitFlex>
-        
+
         {/** 보호자 정보 */}
-        <Flex height={48} padding="0 20px" justify="space-between" backgroundColor={theme.palette.White}>
-          <Text typo="Title3" colorCode={theme.palette.Black}>보호자</Text>
+        <Flex
+          height={48}
+          padding="0 20px"
+          justify="space-between"
+          backgroundColor={theme.palette.White}
+        >
+          <Text typo="Title3" colorCode={theme.palette.Black}>
+            보호자
+          </Text>
           <WidthFitFlex gap={28}>
-            {request && 
+            {request && (
               <>
-                <Text typo="Body3" colorCode={theme.palette.Black}>{request.userName}</Text>
-                <Text typo="Body4" colorCode={theme.palette.Gray500}>{request.userPhone}</Text>
+                <Text typo="Body3" colorCode={theme.palette.Black}>
+                  {request.userName}
+                </Text>
+                <Text typo="Body4" colorCode={theme.palette.Gray500}>
+                  {request.userPhone}
+                </Text>
               </>
-            }
+            )}
           </WidthFitFlex>
         </Flex>
 
-        <Flex direction="column" align="flex-start" padding="0 20px 145px 20px" backgroundColor={theme.palette.White}>
-          {request && (step === 1 ? (
-            <>
-              <Flex padding="16px 0" justify="flex-start" gap={4}>
-                <StepTag step={1} label="기본사항 입력" status="active"/>
-                <StepTag step={2} label="예상금액 입력" status="disabled" onClick={onNextStep}/>
-              </Flex>
-              <ReplyForm request={request} selectedTimeList={timeList} setFormData={setFormData} setIsValid={setIsValid} />
-            </>
-          ) : (
-            <>
-              <Flex padding="16px 0" justify="flex-start" gap={4}>
-                <StepTag step={1} label="기본사항 입력" status="done" onClick={() => setStep(1)}/>
-                <StepTag step={2} label="예상금액 입력" status="active"/>
-              </Flex>
-              <ReplyFormDetail request={request} formData={formData} setFormData={setFormData} setIsValid={setIsValid} />
-            </>
-          ))}
+        <Flex
+          direction="column"
+          align="flex-start"
+          padding="0 20px 145px 20px"
+          backgroundColor={theme.palette.White}
+        >
+          {request &&
+            (step === 1 ? (
+              <>
+                <Flex padding="16px 0" justify="flex-start" gap={4}>
+                  <StepTag step={1} label="기본사항 입력" status="active" />
+                  <StepTag
+                    step={2}
+                    label="예상금액 입력"
+                    status="disabled"
+                    onClick={onNextStep}
+                  />
+                </Flex>
+                <ReplyForm
+                  request={request}
+                  selectedTimeList={timeList}
+                  setFormData={setFormData}
+                  setIsValid={setIsValid}
+                />
+              </>
+            ) : (
+              <>
+                <Flex padding="16px 0" justify="flex-start" gap={4}>
+                  <StepTag
+                    step={1}
+                    label="기본사항 입력"
+                    status="done"
+                    onClick={() => setStep(1)}
+                  />
+                  <StepTag step={2} label="예상금액 입력" status="active" />
+                </Flex>
+                <ReplyFormDetail
+                  request={request}
+                  formData={formData}
+                  setFormData={setFormData}
+                  setIsValid={setIsValid}
+                />
+              </>
+            ))}
         </Flex>
       </Flex>
-      
+
       {/** 하단 버튼 */}
       <FrontBtn
         bg={isValid ? theme.palette.Black : theme.palette.Gray200}
@@ -125,21 +193,43 @@ const ReplyPage = () => {
       </FrontBtn>
       <SalonNavbar />
 
-      <Modal isOpen={isOpenModal} toggleModal={closeModal} closeIcon={false} margin="40px">
+      <Modal
+        isOpen={isOpenModal}
+        toggleModal={closeModal}
+        closeIcon={false}
+        margin="40px"
+      >
         <Flex direction="column" padding="12px 28px" gap={36}>
           <CheckCircle width={56} />
           <Flex direction="column">
-            <Text typo="Body2" colorCode={theme.palette.Black} margin="0 0 18px 0">견적서 보내기 완료!</Text>
-            <Text typo="Caption2" colorCode={theme.palette.Gray400}>보낸 견적서는</Text>
-            <Text typo="Caption2" colorCode={theme.palette.Gray400}>보관함에서 확인이 가능해요</Text>
+            <Text
+              typo="Body2"
+              colorCode={theme.palette.Black}
+              margin="0 0 18px 0"
+            >
+              견적서 보내기 완료!
+            </Text>
+            <Text typo="Caption2" colorCode={theme.palette.Gray400}>
+              보낸 견적서는
+            </Text>
+            <Text typo="Caption2" colorCode={theme.palette.Gray400}>
+              보관함에서 확인이 가능해요
+            </Text>
           </Flex>
-          <Button onClick={onCloseModal} width="100%" borderRadius="8px" bg={theme.palette.Black}>
-            <Text typo="Body3" colorCode={theme.palette.White}>확인</Text>
+          <Button
+            onClick={onCloseModal}
+            width="100%"
+            borderRadius="8px"
+            bg={theme.palette.Black}
+          >
+            <Text typo="Body3" colorCode={theme.palette.White}>
+              확인
+            </Text>
           </Button>
         </Flex>
       </Modal>
     </MobileLayout>
   );
-}
+};
 
 export default ReplyPage;

--- a/apps/salon/src/pages/Quotation/ReplyPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReplyPage.tsx
@@ -40,10 +40,13 @@ const ReplyPage = () => {
   const [isValid, setIsValid] = useState<boolean>(false);
 
   const { data: request, timeList } = useGetDetailRequest(requestId);
+
   const { mutateAsync: submitQuotation, error: postQuotationError } =
     usePostQuotation();
 
   const { isOpenModal, openModal, closeModal } = useModal();
+
+  const { userName, userPhone, pet } = request || {};
 
   const onNextStep = async () => {
     if (step === 1) {
@@ -55,10 +58,10 @@ const ReplyPage = () => {
   };
 
   const handleSubmit = async () => {
-    console.log(formData);
     await submitQuotation(formData);
 
     if (postQuotationError) {
+      // TODO: 에러 처리
       console.error(postQuotationError);
       return;
     } else {
@@ -89,22 +92,22 @@ const ReplyPage = () => {
           padding="14px 20px"
           backgroundColor={theme.palette.White}
         >
-          <Card height="235" borderRadius={16} padding="12px 16px">
-            {request && (
+          {pet && (
+            <Card height="235" borderRadius={16} padding="12px 16px">
               <PetInfo
                 themeVariant="spacious"
-                image={request.pet.image}
-                name={request.pet.name}
-                breed={request.pet.breed}
-                age={request.pet.age}
-                weight={request.pet.weight}
-                gender={request.pet.gender}
-                neutering={request.pet.neutering}
-                character={request.pet.character}
-                diseases={request.pet.diseases}
+                image={pet.image}
+                name={pet.name}
+                breed={pet.breed}
+                age={pet.age}
+                weight={pet.weight}
+                gender={pet.gender}
+                neutering={pet.neutering}
+                character={pet.character}
+                diseases={pet.diseases}
               />
-            )}
-          </Card>
+            </Card>
+          )}
         </HeightFitFlex>
 
         {/** 보호자 정보 */}
@@ -121,10 +124,10 @@ const ReplyPage = () => {
             {request && (
               <>
                 <Text typo="Body3" colorCode={theme.palette.Black}>
-                  {request.userName}
+                  {userName}
                 </Text>
                 <Text typo="Body4" colorCode={theme.palette.Gray500}>
-                  {request.userPhone}
+                  {userPhone}
                 </Text>
               </>
             )}

--- a/apps/salon/src/pages/Quotation/ReplyPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReplyPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { Button, Card, CheckCircle, Flex, FrontBtn, Header, HeightFitFlex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme, WidthFitFlex } from "@duri-fe/ui";
-import { useGetDetailRequest, useModal } from "@duri-fe/utils";
+import { useGetDetailRequest, useModal, usePostQuotation } from "@duri-fe/utils";
 import { defaultQuotationFormData } from "@salon/assets/data/quotation";
 import { QuotationFormData } from "@salon/assets/types/quotation";
 import ReplyForm from "@salon/components/quotation/ReplyForm";
@@ -21,25 +21,35 @@ const ReplyPage = () => {
   const [isValid, setIsValid] = useState<boolean>(false);
 
   const { data: request, timeList } = useGetDetailRequest(requestId);
+  const { mutateAsync: submitQuotation, error: postQuotationError } = usePostQuotation();
 
   const { isOpenModal, openModal, closeModal } = useModal();
 
-  const onNextStep = () => {
+  const onNextStep = async () => {
     if (step === 1) {
       setStep(2);
       setIsValid(false); // 초기화
     } else {
-      handleSubmit();
+      await handleSubmit();
+    }
+  };
+
+  const handleSubmit = async () => {
+    console.log(formData);
+    await submitQuotation(formData);
+    
+    if (postQuotationError) {
+      console.error(postQuotationError);
+      return;
+    } else {
       openModal();
     }
   };
 
-  const handleSubmit = () => {
-    console.log(formData);
-    // API 호출 필요
+  const onCloseModal = () => {
     closeModal();
-    // 네비게이션 필요
-  };
+    navigate('/');
+  }
 
   if (!requestId) return null;
 
@@ -123,7 +133,7 @@ const ReplyPage = () => {
             <Text typo="Caption2" colorCode={theme.palette.Gray400}>보낸 견적서는</Text>
             <Text typo="Caption2" colorCode={theme.palette.Gray400}>보관함에서 확인이 가능해요</Text>
           </Flex>
-          <Button onClick={closeModal} width="100%" borderRadius="8px" bg={theme.palette.Black}>
+          <Button onClick={onCloseModal} width="100%" borderRadius="8px" bg={theme.palette.Black}>
             <Text typo="Body3" colorCode={theme.palette.White}>확인</Text>
           </Button>
         </Flex>

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
-import { useGetNewRequestList, useModal } from "@duri-fe/utils";
+import { useGetReservedQuotationList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
 import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
@@ -12,7 +12,8 @@ const ReservationPage = () => {
   const [selectedTab, setSelectedTab] = useState<string>('reserved')
   const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
   const { isOpenModal, openModal, closeModal } = useModal();
-  const { data: newRequestList } = useGetNewRequestList();
+  const { data: reservationList } = useGetReservedQuotationList();
+
 
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
@@ -58,22 +59,20 @@ const ReservationPage = () => {
         />
       </Flex>
 
-      {newRequestList && newRequestList.length > 0 ? (
+      {reservationList && reservationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
-          {newRequestList.map((request) => (
-            <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
+          {reservationList.map((item) => (
+            <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
               <Card borderRadius={12} padding="6px">
                 <PetInfo
                   themeVariant="medium"
-                  image={request.petImage}
-                  name={request.petName}
-                  breed={request.petBreed}
-                  age={request.petAge}
-                  neutering={request.petNeutering}
-
-                  // TODO : gender, weight API 수정 필요함
-                  gender="F"
-                  weight={7.3}
+                  image={item.petDetailResponse.image}
+                  name={item.petDetailResponse.name}
+                  breed={item.petDetailResponse.breed}
+                  age={item.petDetailResponse.age}
+                  neutering={item.petDetailResponse.neutering}
+                  gender={item.petDetailResponse.gender}
+                  weight={item.petDetailResponse.weight}
                 />
               </Card>
             </Flex>
@@ -82,7 +81,7 @@ const ReservationPage = () => {
       ) : (
         // TODO : 임시 대체뷰 수정 필요
         <FlexGrow>
-          <Text>새로운 요청이 없어요.</Text>
+          <Text>예약된 일정이 없어요.</Text>
         </FlexGrow>
       )}
 

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
 import { useGetCompletedQuotationList, useGetReservedQuotationList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
+import { DetailQuotation } from "@salon/components/quotation/DetailQuotation";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
 const ReservationPage = () => {
@@ -134,11 +135,11 @@ const ReservationPage = () => {
       {selectedRequestId &&
         <>
           <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'reserved')} toggleModal={closeModal}>
-            시술 예정!!
+            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} />
           </Modal>
 
           <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'complete')} toggleModal={closeModal}>
-            시술 완료 !!
+            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} enableCompleteButton />
           </Modal>
         </>
       }

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -4,19 +4,17 @@ import { useNavigate } from "react-router-dom";
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
 import { useGetReservedQuotationList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
-import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
 const ReservationPage = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<string>('reserved')
-  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
   const { isOpenModal, openModal, closeModal } = useModal();
   const { data: reservationList } = useGetReservedQuotationList();
 
 
-  const handleRequestClick = (requestId: number) => {
-    setSelectedRequestId(requestId);
+  const handleReservationClick = (requestId: number) => {
+    console.log(requestId)
     openModal();
   }
 
@@ -62,17 +60,24 @@ const ReservationPage = () => {
       {reservationList && reservationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
           {reservationList.map((item) => (
-            <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
-              <Card borderRadius={12} padding="6px">
+            <Flex key={item.requestId} onClick={() => handleReservationClick(item.requestId)}>
+              <Card borderRadius={12} padding="12px">
                 <PetInfo
                   themeVariant="medium"
                   image={item.petDetailResponse.image}
                   name={item.petDetailResponse.name}
                   breed={item.petDetailResponse.breed}
                   age={item.petDetailResponse.age}
-                  neutering={item.petDetailResponse.neutering}
                   gender={item.petDetailResponse.gender}
                   weight={item.petDetailResponse.weight}
+                  dday={item.dday}
+                  groomer={{
+                    groomerName: item.groomerName,
+                    groomerImage: item.groomerImage,
+                    date: item.date,
+                    startTime: item.startTime,
+                    endTime: item.endTime
+                  }}
                 />
               </Card>
             </Flex>
@@ -87,9 +92,9 @@ const ReservationPage = () => {
 
       <SalonNavbar />
 
-      {selectedRequestId &&
-        <Modal title='요청서' margin="20px" isOpen={isOpenModal} toggleModal={closeModal}>
-          <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
+      {reservationList &&
+        <Modal title='견적서' margin="20px" isOpen={isOpenModal} toggleModal={closeModal}>
+          예약 견적
         </Modal>
       }
     </MobileLayout>

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -85,32 +85,43 @@ const ReservationPage = () => {
       {selectedTab === 'reserved' ? (
         reservationList && reservationList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
-            {reservationList.map((item) => (
-              <Flex
-                key={item.requestId}
-                onClick={() => handleRequestClick(item.requestId)}
-              >
-                <Card borderRadius={12} padding="12px" shadow="none">
-                  <PetInfo
-                    themeVariant="medium"
-                    image={item.petDetailResponse.image}
-                    name={item.petDetailResponse.name}
-                    breed={item.petDetailResponse.breed}
-                    age={item.petDetailResponse.age}
-                    gender={item.petDetailResponse.gender}
-                    weight={item.petDetailResponse.weight}
-                    dday={item.dday}
-                    groomer={{
-                      groomerName: item.groomerName,
-                      groomerImage: item.groomerImage,
-                      date: item.date,
-                      startTime: item.startTime,
-                      endTime: item.endTime,
-                    }}
-                  />
-                </Card>
-              </Flex>
-            ))}
+            {reservationList.map(
+              ({
+                requestId,
+                petDetailResponse,
+                dday,
+                groomerName,
+                groomerImage,
+                date,
+                startTime,
+                endTime,
+              }) => (
+                <Flex
+                  key={requestId}
+                  onClick={() => handleRequestClick(requestId)}
+                >
+                  <Card borderRadius={12} padding="12px" shadow="none">
+                    <PetInfo
+                      themeVariant="medium"
+                      image={petDetailResponse.image}
+                      name={petDetailResponse.name}
+                      breed={petDetailResponse.breed}
+                      age={petDetailResponse.age}
+                      gender={petDetailResponse.gender}
+                      weight={petDetailResponse.weight}
+                      dday={dday}
+                      groomer={{
+                        groomerName: groomerName,
+                        groomerImage: groomerImage,
+                        date: date,
+                        startTime: startTime,
+                        endTime: endTime,
+                      }}
+                    />
+                  </Card>
+                </Flex>
+              ),
+            )}
           </Flex>
         ) : (
           // TODO : 임시 대체뷰 수정 필요
@@ -120,32 +131,42 @@ const ReservationPage = () => {
         )
       ) : completedQuotationList && completedQuotationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
-          {completedQuotationList.map((item) => (
-            <Flex
-              key={item.requestId}
-              onClick={() => handleRequestClick(item.requestId)}
-            >
-              <Card borderRadius={12} padding="12px" shadow="none">
-                <PetInfo
-                  themeVariant="medium"
-                  image={item.petDetailResponse.image}
-                  name={item.petDetailResponse.name}
-                  breed={item.petDetailResponse.breed}
-                  age={item.petDetailResponse.age}
-                  gender={item.petDetailResponse.gender}
-                  weight={item.petDetailResponse.weight}
-                  complete
-                  groomer={{
-                    groomerName: item.groomerName,
-                    groomerImage: item.groomerImage,
-                    date: item.date,
-                    startTime: item.startTime,
-                    endTime: item.endTime,
-                  }}
-                />
-              </Card>
-            </Flex>
-          ))}
+          {completedQuotationList.map(
+            ({
+              requestId,
+              petDetailResponse,
+              groomerName,
+              groomerImage,
+              date,
+              startTime,
+              endTime,
+            }) => (
+              <Flex
+                key={requestId}
+                onClick={() => handleRequestClick(requestId)}
+              >
+                <Card borderRadius={12} padding="12px" shadow="none">
+                  <PetInfo
+                    themeVariant="medium"
+                    image={petDetailResponse.image}
+                    name={petDetailResponse.name}
+                    breed={petDetailResponse.breed}
+                    age={petDetailResponse.age}
+                    gender={petDetailResponse.gender}
+                    weight={petDetailResponse.weight}
+                    complete
+                    groomer={{
+                      groomerName: groomerName,
+                      groomerImage: groomerImage,
+                      date: date,
+                      startTime: startTime,
+                      endTime: endTime,
+                    }}
+                  />
+                </Card>
+              </Flex>
+            ),
+          )}
         </Flex>
       ) : (
         // TODO : 임시 대체뷰 수정 필요

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
-import { useGetReservedQuotationList, useModal } from "@duri-fe/utils";
+import { useGetCompletedQuotationList, useGetReservedQuotationList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
@@ -11,7 +11,7 @@ const ReservationPage = () => {
   const [selectedTab, setSelectedTab] = useState<string>('reserved')
   const { isOpenModal, openModal, closeModal } = useModal();
   const { data: reservationList } = useGetReservedQuotationList();
-
+  const { data: completedQuotationList } = useGetCompletedQuotationList();
 
   const handleReservationClick = (requestId: number) => {
     console.log(requestId)
@@ -57,7 +57,8 @@ const ReservationPage = () => {
         />
       </Flex>
 
-      {reservationList && reservationList.length > 0 ? (
+      {selectedTab === 'reserved' ?
+      (reservationList && reservationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
           {reservationList.map((item) => (
             <Flex key={item.requestId} onClick={() => handleReservationClick(item.requestId)}>
@@ -88,6 +89,39 @@ const ReservationPage = () => {
         <FlexGrow>
           <Text>예약된 일정이 없어요.</Text>
         </FlexGrow>
+      )) : (
+        completedQuotationList && completedQuotationList.length > 0 ? (
+          <Flex direction="column" gap={8} padding="30px 20px">
+            {completedQuotationList.map((item) => (
+              <Flex key={item.requestId}>
+                <Card borderRadius={12} padding="12px">
+                  <PetInfo
+                    themeVariant="medium"
+                    image={item.petDetailResponse.image}
+                    name={item.petDetailResponse.name}
+                    breed={item.petDetailResponse.breed}
+                    age={item.petDetailResponse.age}
+                    gender={item.petDetailResponse.gender}
+                    weight={item.petDetailResponse.weight}
+                    complete
+                    groomer={{
+                      groomerName: item.groomerName,
+                      groomerImage: item.groomerImage,
+                      date: item.date,
+                      startTime: item.startTime,
+                      endTime: item.endTime
+                    }}
+                  />
+                </Card>
+              </Flex>
+            ))}
+          </Flex>
+        ) : (
+          // TODO : 임시 대체뷰 수정 필요
+          <FlexGrow>
+            <Text>완료된 일정이 없어요.</Text>
+          </FlexGrow>
+        )
       )}
 
       <SalonNavbar />

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -9,12 +9,16 @@ import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 const ReservationPage = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<string>('reserved')
+  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
+
+
   const { isOpenModal, openModal, closeModal } = useModal();
+
   const { data: reservationList } = useGetReservedQuotationList();
   const { data: completedQuotationList } = useGetCompletedQuotationList();
 
-  const handleReservationClick = (requestId: number) => {
-    console.log(requestId)
+  const handleRequestClick = (requestId: number) => {
+    setSelectedRequestId(requestId);
     openModal();
   }
 
@@ -61,8 +65,8 @@ const ReservationPage = () => {
       (reservationList && reservationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
           {reservationList.map((item) => (
-            <Flex key={item.requestId} onClick={() => handleReservationClick(item.requestId)}>
-              <Card borderRadius={12} padding="12px">
+            <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
+              <Card borderRadius={12} padding="12px" shadow="none">
                 <PetInfo
                   themeVariant="medium"
                   image={item.petDetailResponse.image}
@@ -93,8 +97,8 @@ const ReservationPage = () => {
         completedQuotationList && completedQuotationList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
             {completedQuotationList.map((item) => (
-              <Flex key={item.requestId}>
-                <Card borderRadius={12} padding="12px">
+              <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
+                <Card borderRadius={12} padding="12px" shadow="none">
                   <PetInfo
                     themeVariant="medium"
                     image={item.petDetailResponse.image}
@@ -126,10 +130,17 @@ const ReservationPage = () => {
 
       <SalonNavbar />
 
-      {reservationList &&
-        <Modal title='견적서' margin="20px" isOpen={isOpenModal} toggleModal={closeModal}>
-          예약 견적
-        </Modal>
+
+      {selectedRequestId &&
+        <>
+          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'reserved')} toggleModal={closeModal}>
+            시술 예정!!
+          </Modal>
+
+          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'complete')} toggleModal={closeModal}>
+            시술 완료 !!
+          </Modal>
+        </>
       }
     </MobileLayout>
   )

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -1,17 +1,31 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
-import { useGetCompletedQuotationList, useGetReservedQuotationList, useModal } from "@duri-fe/utils";
-import styled from "@emotion/styled";
-import { DetailQuotation } from "@salon/components/quotation/DetailQuotation";
-import { TabBarItem } from "@salon/components/quotation/TabBarItem"
+import {
+  Card,
+  Flex,
+  MobileLayout,
+  Modal,
+  PetInfo,
+  SalonNavbar,
+  Text,
+  theme,
+} from '@duri-fe/ui';
+import {
+  useGetCompletedQuotationList,
+  useGetReservedQuotationList,
+  useModal,
+} from '@duri-fe/utils';
+import styled from '@emotion/styled';
+import { DetailQuotation } from '@salon/components/quotation/DetailQuotation';
+import { TabBarItem } from '@salon/components/quotation/TabBarItem';
 
 const ReservationPage = () => {
   const navigate = useNavigate();
-  const [selectedTab, setSelectedTab] = useState<string>('reserved')
-  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
-
+  const [selectedTab, setSelectedTab] = useState<string>('reserved');
+  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(
+    null,
+  );
 
   const { isOpenModal, openModal, closeModal } = useModal();
 
@@ -21,15 +35,15 @@ const ReservationPage = () => {
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
     openModal();
-  }
+  };
 
   const handleNavigate = () => {
     navigate('/quotation');
-  }
+  };
 
   const handleToggleTab = (currTab: string) => {
     setSelectedTab(currTab);
-  }
+  };
 
   return (
     <MobileLayout backgroundColor={theme.palette.Gray_White}>
@@ -40,7 +54,13 @@ const ReservationPage = () => {
         justify="flex-start"
         backgroundColor={theme.palette.White}
       >
-        <TabBarItem label="견적" selected={false} typo="Body1Light" fitContent onClick={handleNavigate} />
+        <TabBarItem
+          label="견적"
+          selected={false}
+          typo="Body1Light"
+          fitContent
+          onClick={handleNavigate}
+        />
         <TabBarItem label="예약" selected typo="Body1" fitContent />
       </Flex>
       <Flex
@@ -48,57 +68,28 @@ const ReservationPage = () => {
         justify="flex-start"
         backgroundColor={theme.palette.White}
       >
-        <TabBarItem 
-          label="예약 확정" 
-          selected={selectedTab === 'reserved'} 
+        <TabBarItem
+          label="예약 확정"
+          selected={selectedTab === 'reserved'}
           typo={selectedTab === 'reserved' ? 'Title3' : 'Body2Light'}
           onClick={() => handleToggleTab('reserved')}
         />
-        <TabBarItem 
-          label="시술 완료" 
-          selected={selectedTab === 'complete'} 
+        <TabBarItem
+          label="시술 완료"
+          selected={selectedTab === 'complete'}
           typo={selectedTab === 'complete' ? 'Title3' : 'Body2Light'}
           onClick={() => handleToggleTab('complete')}
         />
       </Flex>
 
-      {selectedTab === 'reserved' ?
-      (reservationList && reservationList.length > 0 ? (
-        <Flex direction="column" gap={8} padding="30px 20px">
-          {reservationList.map((item) => (
-            <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
-              <Card borderRadius={12} padding="12px" shadow="none">
-                <PetInfo
-                  themeVariant="medium"
-                  image={item.petDetailResponse.image}
-                  name={item.petDetailResponse.name}
-                  breed={item.petDetailResponse.breed}
-                  age={item.petDetailResponse.age}
-                  gender={item.petDetailResponse.gender}
-                  weight={item.petDetailResponse.weight}
-                  dday={item.dday}
-                  groomer={{
-                    groomerName: item.groomerName,
-                    groomerImage: item.groomerImage,
-                    date: item.date,
-                    startTime: item.startTime,
-                    endTime: item.endTime
-                  }}
-                />
-              </Card>
-            </Flex>
-          ))}
-        </Flex>
-      ) : (
-        // TODO : 임시 대체뷰 수정 필요
-        <FlexGrow>
-          <Text>예약된 일정이 없어요.</Text>
-        </FlexGrow>
-      )) : (
-        completedQuotationList && completedQuotationList.length > 0 ? (
+      {selectedTab === 'reserved' ? (
+        reservationList && reservationList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
-            {completedQuotationList.map((item) => (
-              <Flex key={item.requestId} onClick={() => handleRequestClick(item.requestId)}>
+            {reservationList.map((item) => (
+              <Flex
+                key={item.requestId}
+                onClick={() => handleRequestClick(item.requestId)}
+              >
                 <Card borderRadius={12} padding="12px" shadow="none">
                   <PetInfo
                     themeVariant="medium"
@@ -108,13 +99,13 @@ const ReservationPage = () => {
                     age={item.petDetailResponse.age}
                     gender={item.petDetailResponse.gender}
                     weight={item.petDetailResponse.weight}
-                    complete
+                    dday={item.dday}
                     groomer={{
                       groomerName: item.groomerName,
                       groomerImage: item.groomerImage,
                       date: item.date,
                       startTime: item.startTime,
-                      endTime: item.endTime
+                      endTime: item.endTime,
                     }}
                   />
                 </Card>
@@ -124,31 +115,81 @@ const ReservationPage = () => {
         ) : (
           // TODO : 임시 대체뷰 수정 필요
           <FlexGrow>
-            <Text>완료된 일정이 없어요.</Text>
+            <Text>예약된 일정이 없어요.</Text>
           </FlexGrow>
         )
+      ) : completedQuotationList && completedQuotationList.length > 0 ? (
+        <Flex direction="column" gap={8} padding="30px 20px">
+          {completedQuotationList.map((item) => (
+            <Flex
+              key={item.requestId}
+              onClick={() => handleRequestClick(item.requestId)}
+            >
+              <Card borderRadius={12} padding="12px" shadow="none">
+                <PetInfo
+                  themeVariant="medium"
+                  image={item.petDetailResponse.image}
+                  name={item.petDetailResponse.name}
+                  breed={item.petDetailResponse.breed}
+                  age={item.petDetailResponse.age}
+                  gender={item.petDetailResponse.gender}
+                  weight={item.petDetailResponse.weight}
+                  complete
+                  groomer={{
+                    groomerName: item.groomerName,
+                    groomerImage: item.groomerImage,
+                    date: item.date,
+                    startTime: item.startTime,
+                    endTime: item.endTime,
+                  }}
+                />
+              </Card>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        // TODO : 임시 대체뷰 수정 필요
+        <FlexGrow>
+          <Text>완료된 일정이 없어요.</Text>
+        </FlexGrow>
       )}
 
       <SalonNavbar />
 
-
-      {selectedRequestId &&
+      {selectedRequestId && (
         <>
-          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'reserved')} toggleModal={closeModal}>
-            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} />
+          <Modal
+            title="견적서"
+            margin="20px"
+            isOpen={isOpenModal && selectedTab === 'reserved'}
+            toggleModal={closeModal}
+          >
+            <DetailQuotation
+              requestId={selectedRequestId}
+              closeModal={closeModal}
+            />
           </Modal>
 
-          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'complete')} toggleModal={closeModal}>
-            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} enableCompleteButton />
+          <Modal
+            title="견적서"
+            margin="20px"
+            isOpen={isOpenModal && selectedTab === 'complete'}
+            toggleModal={closeModal}
+          >
+            <DetailQuotation
+              requestId={selectedRequestId}
+              closeModal={closeModal}
+              enableCompleteButton
+            />
           </Modal>
         </>
-      }
+      )}
     </MobileLayout>
-  )
-}
+  );
+};
 
 const FlexGrow = styled(Flex)`
   flex-grow: 1;
-`
+`;
 
 export default ReservationPage;

--- a/apps/salon/src/pages/Quotation/ReservationPage.tsx
+++ b/apps/salon/src/pages/Quotation/ReservationPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
+import { useGetNewRequestList, useModal } from "@duri-fe/utils";
+import styled from "@emotion/styled";
+import { DetailRequest } from "@salon/components/quotation/DetailRequest";
+import { TabBarItem } from "@salon/components/quotation/TabBarItem"
+
+const ReservationPage = () => {
+  const navigate = useNavigate();
+  const [selectedTab, setSelectedTab] = useState<string>('reserved')
+  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
+  const { isOpenModal, openModal, closeModal } = useModal();
+  const { data: newRequestList } = useGetNewRequestList();
+
+  const handleRequestClick = (requestId: number) => {
+    setSelectedRequestId(requestId);
+    openModal();
+  }
+
+  const handleNavigate = () => {
+    navigate('/quotation');
+  }
+
+  const handleToggleTab = (currTab: string) => {
+    setSelectedTab(currTab);
+  }
+
+  return (
+    <MobileLayout backgroundColor={theme.palette.Gray_White}>
+      <Flex
+        height={60}
+        padding="0 20px"
+        gap={16}
+        justify="flex-start"
+        backgroundColor={theme.palette.White}
+      >
+        <TabBarItem label="견적" selected={false} typo="Body1Light" fitContent onClick={handleNavigate} />
+        <TabBarItem label="예약" selected typo="Body1" fitContent />
+      </Flex>
+      <Flex
+        height={48}
+        justify="flex-start"
+        backgroundColor={theme.palette.White}
+      >
+        <TabBarItem 
+          label="예약 확정" 
+          selected={selectedTab === 'reserved'} 
+          typo={selectedTab === 'reserved' ? 'Title3' : 'Body2Light'}
+          onClick={() => handleToggleTab('reserved')}
+        />
+        <TabBarItem 
+          label="시술 완료" 
+          selected={selectedTab === 'complete'} 
+          typo={selectedTab === 'complete' ? 'Title3' : 'Body2Light'}
+          onClick={() => handleToggleTab('complete')}
+        />
+      </Flex>
+
+      {newRequestList && newRequestList.length > 0 ? (
+        <Flex direction="column" gap={8} padding="30px 20px">
+          {newRequestList.map((request) => (
+            <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
+              <Card borderRadius={12} padding="6px">
+                <PetInfo
+                  themeVariant="medium"
+                  image={request.petImage}
+                  name={request.petName}
+                  breed={request.petBreed}
+                  age={request.petAge}
+                  neutering={request.petNeutering}
+
+                  // TODO : gender, weight API 수정 필요함
+                  gender="F"
+                  weight={7.3}
+                />
+              </Card>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        // TODO : 임시 대체뷰 수정 필요
+        <FlexGrow>
+          <Text>새로운 요청이 없어요.</Text>
+        </FlexGrow>
+      )}
+
+      <SalonNavbar />
+
+      {selectedRequestId &&
+        <Modal title='요청서' margin="20px" isOpen={isOpenModal} toggleModal={closeModal}>
+          <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
+        </Modal>
+      }
+    </MobileLayout>
+  )
+}
+
+const FlexGrow = styled(Flex)`
+  flex-grow: 1;
+`
+
+export default ReservationPage;

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -1,17 +1,34 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, SalonTag, Text, theme, WidthFitFlex } from "@duri-fe/ui"
-import { useGetApprovedQuotationList, useGetNewRequestList, useModal } from "@duri-fe/utils";
-import styled from "@emotion/styled";
-import { DetailQuotation } from "@salon/components/quotation/DetailQuotation";
-import { DetailRequest } from "@salon/components/quotation/DetailRequest";
-import { TabBarItem } from "@salon/components/quotation/TabBarItem"
+import {
+  Card,
+  Flex,
+  MobileLayout,
+  Modal,
+  PetInfo,
+  SalonNavbar,
+  SalonTag,
+  Text,
+  theme,
+  WidthFitFlex,
+} from '@duri-fe/ui';
+import {
+  useGetApprovedQuotationList,
+  useGetNewRequestList,
+  useModal,
+} from '@duri-fe/utils';
+import styled from '@emotion/styled';
+import { DetailQuotation } from '@salon/components/quotation/DetailQuotation';
+import { DetailRequest } from '@salon/components/quotation/DetailRequest';
+import { TabBarItem } from '@salon/components/quotation/TabBarItem';
 
 const QuotationPage = () => {
   const navigate = useNavigate();
-  const [selectedTab, setSelectedTab] = useState<string>('new')
-  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
+  const [selectedTab, setSelectedTab] = useState<string>('new');
+  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(
+    null,
+  );
 
   const { isOpenModal, openModal, closeModal } = useModal();
 
@@ -21,15 +38,15 @@ const QuotationPage = () => {
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
     openModal();
-  }
+  };
 
   const handleNavigate = () => {
     navigate('/quotation/reservation');
-  }
+  };
 
   const handleToggleTab = (currTab: string) => {
     setSelectedTab(currTab);
-  }
+  };
 
   return (
     <MobileLayout backgroundColor={theme.palette.Gray_White}>
@@ -54,25 +71,28 @@ const QuotationPage = () => {
         justify="flex-start"
         backgroundColor={theme.palette.White}
       >
-        <TabBarItem 
-          label="새로운 견적 요청" 
-          selected={selectedTab === 'new'} 
+        <TabBarItem
+          label="새로운 견적 요청"
+          selected={selectedTab === 'new'}
           typo={selectedTab === 'new' ? 'Title3' : 'Body2Light'}
           onClick={() => handleToggleTab('new')}
         />
-        <TabBarItem 
-          label="답장한 견적" 
-          selected={selectedTab === 'approved'} 
+        <TabBarItem
+          label="답장한 견적"
+          selected={selectedTab === 'approved'}
           typo={selectedTab === 'approved' ? 'Title3' : 'Body2Light'}
           onClick={() => handleToggleTab('approved')}
         />
       </Flex>
 
-      {selectedTab === 'new' ? 
-        (newRequestList && newRequestList.length > 0 ? (
+      {selectedTab === 'new' ? (
+        newRequestList && newRequestList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
             {newRequestList.map((request) => (
-              <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
+              <Flex
+                key={request.requestId}
+                onClick={() => handleRequestClick(request.requestId)}
+              >
                 <Card borderRadius={12} padding="6px" shadow="none">
                   <PetInfo
                     themeVariant="medium"
@@ -81,7 +101,6 @@ const QuotationPage = () => {
                     breed={request.petBreed}
                     age={request.petAge}
                     neutering={request.petNeutering}
-
                     // TODO : gender, weight API 수정 필요함
                     gender="F"
                     weight={7.3}
@@ -95,71 +114,120 @@ const QuotationPage = () => {
           <FlexGrow>
             <Text>새로운 요청이 없어요.</Text>
           </FlexGrow>
-        )) : (
-          approvedQuotationList && approvedQuotationList.length > 0 ? (
-            <Flex direction="column" gap={8} padding="30px 20px">
-            {approvedQuotationList.map((quotation) => (
-              <Flex key={quotation.requestId} onClick={() => handleRequestClick(quotation.requestId)}>
-                <Card borderRadius={12} padding="6px" direction="row" shadow="none">
-                  <PetInfo
-                    themeVariant="medium"
-                    image={quotation.petImage}
-                    name={quotation.petName}
-                    breed={quotation.petBreed}
-                    age={quotation.petAge}
-                    neutering={quotation.petNeutering}
-
-                    // TODO : gender, weight API 수정 필요함
-                    gender="F"
-                    weight={7.3}
+        )
+      ) : approvedQuotationList && approvedQuotationList.length > 0 ? (
+        <Flex direction="column" gap={8} padding="30px 20px">
+          {approvedQuotationList.map((quotation) => (
+            <Flex
+              key={quotation.requestId}
+              onClick={() => handleRequestClick(quotation.requestId)}
+            >
+              <PetInfoCard
+                borderRadius={12}
+                padding="6px"
+                direction="row"
+                shadow="none"
+              >
+                <PetInfo
+                  themeVariant="medium"
+                  image={quotation.petImage}
+                  name={quotation.petName}
+                  breed={quotation.petBreed}
+                  age={quotation.petAge}
+                  neutering={quotation.petNeutering}
+                  // TODO : gender, weight API 수정 필요함
+                  gender="F"
+                  weight={7.3}
+                />
+                <TagWrapper margin="0 14px">
+                  <SalonTag
+                    content={
+                      quotation.status === 'approved'
+                        ? '수락됨'
+                        : quotation.status === 'expired'
+                          ? '만료됨'
+                          : '대기중'
+                    }
+                    bg={
+                      quotation.status === 'approved'
+                        ? theme.palette.Normal100
+                        : theme.palette.Gray50
+                    }
+                    colorCode={
+                      quotation.status === 'approved'
+                        ? theme.palette.Normal700
+                        : theme.palette.Gray300
+                    }
+                    typo="Label3"
+                    borderRadius={99}
+                    width="auto"
+                    height={26}
+                    padding="6px 10px"
                   />
-                  <TagWrapper margin="0 14px">
-                    <SalonTag
-                      content={quotation.status === 'approved' ? '수락됨' : quotation.status === 'expired' ? '만료됨' : '대기중'}
-                      bg={quotation.status === 'approved' ? theme.palette.Normal100 : theme.palette.Gray50} 
-                      colorCode={quotation.status === 'approved' ? theme.palette.Normal700 : theme.palette.Gray300} 
-                      typo="Label3"
-                      borderRadius={99}
-                      width="auto"
-                      height={26}
-                      padding="6px 10px"
-                    />
-                  </TagWrapper>
-                </Card>
-              </Flex>
-            ))}
-          </Flex>
-        ) : (
-          // TODO : 임시 대체뷰 수정 필요
-          <FlexGrow>
-            <Text>답장한 견적이 없어요.</Text>
-          </FlexGrow>
-        ))
-      }
+                </TagWrapper>
+                <TimeAgoText typo="Caption3" colorCode={theme.palette.Gray300}>
+                  1시간전
+                </TimeAgoText>
+              </PetInfoCard>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        // TODO : 임시 대체뷰 수정 필요
+        <FlexGrow>
+          <Text>답장한 견적이 없어요.</Text>
+        </FlexGrow>
+      )}
 
       <SalonNavbar />
 
-      {selectedRequestId &&
+      {selectedRequestId && (
         <>
-          <Modal title='요청서' margin="20px" isOpen={isOpenModal && (selectedTab === 'new')} toggleModal={closeModal}>
-            <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
+          <Modal
+            title="요청서"
+            margin="20px"
+            isOpen={isOpenModal && selectedTab === 'new'}
+            toggleModal={closeModal}
+          >
+            <DetailRequest
+              requestId={selectedRequestId}
+              closeModal={closeModal}
+            />
           </Modal>
 
-          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'approved')} toggleModal={closeModal}>
-            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} />
+          <Modal
+            title="견적서"
+            margin="20px"
+            isOpen={isOpenModal && selectedTab === 'approved'}
+            toggleModal={closeModal}
+          >
+            <DetailQuotation
+              requestId={selectedRequestId}
+              closeModal={closeModal}
+            />
           </Modal>
         </>
-      }
+      )}
     </MobileLayout>
-  )
-}
+  );
+};
 
 const FlexGrow = styled(Flex)`
   flex-grow: 1;
-`
+`;
 
 const TagWrapper = styled(WidthFitFlex)`
   flex-shrink: 0;
-`
+`;
+
+const PetInfoCard = styled(Card)`
+  position: relative;
+`;
+
+const TimeAgoText = styled(Text)`
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+`;
 
 export default QuotationPage;

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 
-import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, theme } from "@duri-fe/ui"
+import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
 import { useGetNewRequestList, useModal } from "@duri-fe/utils";
+import styled from "@emotion/styled";
 import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
@@ -42,26 +43,33 @@ const QuotationPage = () => {
         <TabBarItem label="답장한 견적" selected={false} typo="Body3" />
       </Flex>
 
-      <Flex direction="column" gap={8} padding="30px 20px">
-        {newRequestList?.map((request) => (
-          <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
-            <Card borderRadius={12} padding="6px">
-              <PetInfo
-                themeVariant="medium"
-                image={request.petImage}
-                name={request.petName}
-                breed={request.petBreed}
-                age={request.petAge}
-                neutering={request.petNeutering}
+      {newRequestList && newRequestList.length > 0 ? (
+        <Flex direction="column" gap={8} padding="30px 20px">
+          {newRequestList.map((request) => (
+            <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
+              <Card borderRadius={12} padding="6px">
+                <PetInfo
+                  themeVariant="medium"
+                  image={request.petImage}
+                  name={request.petName}
+                  breed={request.petBreed}
+                  age={request.petAge}
+                  neutering={request.petNeutering}
 
-                // TODO : gender, weight API 수정 필요함
-                gender="F"
-                weight={7.3}
-              />
-            </Card>
-          </Flex>
-        ))}
-      </Flex>
+                  // TODO : gender, weight API 수정 필요함
+                  gender="F"
+                  weight={7.3}
+                />
+              </Card>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        // TODO : 임시 대체뷰 수정 필요
+        <FlexGrow>
+          <Text>새로운 요청이 없어요.</Text>
+        </FlexGrow>
+      )}
 
       <SalonNavbar />
 
@@ -73,5 +81,9 @@ const QuotationPage = () => {
     </MobileLayout>
   )
 }
+
+const FlexGrow = styled(Flex)`
+  flex-grow: 1;
+`
 
 export default QuotationPage;

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -11,7 +11,7 @@ const QuotationPage = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<string>('new')
   const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
-  const [selectedQuotationId, setSelectedQuotationId] = useState<number | null>(null);
+
   const { isOpenModal, openModal, closeModal } = useModal();
 
   const { data: newRequestList } = useGetNewRequestList();
@@ -20,11 +20,6 @@ const QuotationPage = () => {
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
     openModal();
-  }
-
-  const handleQuotationClick = (requestId: number) => {
-    setSelectedQuotationId(requestId);
-    // openModal();
   }
 
   const handleNavigate = () => {
@@ -77,7 +72,7 @@ const QuotationPage = () => {
           <Flex direction="column" gap={8} padding="30px 20px">
             {newRequestList.map((request) => (
               <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
-                <Card borderRadius={12} padding="6px">
+                <Card borderRadius={12} padding="6px" shadow="none">
                   <PetInfo
                     themeVariant="medium"
                     image={request.petImage}
@@ -103,8 +98,8 @@ const QuotationPage = () => {
           approvedQuotationList && approvedQuotationList.length > 0 ? (
             <Flex direction="column" gap={8} padding="30px 20px">
             {approvedQuotationList.map((quotation) => (
-              <Flex key={quotation.requestId} onClick={() => handleQuotationClick(quotation.requestId)}>
-                <Card borderRadius={12} padding="6px" direction="row">
+              <Flex key={quotation.requestId} onClick={() => handleRequestClick(quotation.requestId)}>
+                <Card borderRadius={12} padding="6px" direction="row" shadow="none">
                   <PetInfo
                     themeVariant="medium"
                     image={quotation.petImage}
@@ -144,15 +139,15 @@ const QuotationPage = () => {
       <SalonNavbar />
 
       {selectedRequestId &&
-        <Modal title='요청서' margin="20px" isOpen={isOpenModal && (selectedTab === 'new')} toggleModal={closeModal}>
-          <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
-        </Modal>
-      }
+        <>
+          <Modal title='요청서' margin="20px" isOpen={isOpenModal && (selectedTab === 'new')} toggleModal={closeModal}>
+            <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
+          </Modal>
 
-      {selectedQuotationId &&
-        <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'approved')} toggleModal={closeModal}>
-          <DetailRequest requestId={selectedQuotationId} closeModal={closeModal} />
-        </Modal>
+          <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'approved')} toggleModal={closeModal}>
+            견적서 작성 완료!!
+          </Modal>
+        </>
       }
     </MobileLayout>
   )

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
 import { useGetNewRequestList, useModal } from "@duri-fe/utils";
@@ -7,14 +8,23 @@ import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
 const QuotationPage = () => {
-  const { isOpenModal, openModal, closeModal } = useModal();
+  const navigate = useNavigate();
+  const [selectedTab, setSelectedTab] = useState<string>('new')
   const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
-
+  const { isOpenModal, openModal, closeModal } = useModal();
   const { data: newRequestList } = useGetNewRequestList();
 
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
     openModal();
+  }
+
+  const handleNavigate = () => {
+    navigate('/quotation/reservation');
+  }
+
+  const handleToggleTab = (currTab: string) => {
+    setSelectedTab(currTab);
   }
 
   return (
@@ -32,6 +42,7 @@ const QuotationPage = () => {
           selected={false}
           typo="Body1Light"
           fitContent
+          onClick={handleNavigate}
         />
       </Flex>
       <Flex
@@ -39,37 +50,49 @@ const QuotationPage = () => {
         justify="flex-start"
         backgroundColor={theme.palette.White}
       >
-        <TabBarItem label="새로운 견적 요청" selected typo="Title3" />
-        <TabBarItem label="답장한 견적" selected={false} typo="Body3" />
+        <TabBarItem 
+          label="새로운 견적 요청" 
+          selected={selectedTab === 'new'} 
+          typo={selectedTab === 'new' ? 'Title3' : 'Body2Light'}
+          onClick={() => handleToggleTab('new')}
+        />
+        <TabBarItem 
+          label="답장한 견적" 
+          selected={selectedTab === 'written'} 
+          typo={selectedTab === 'written' ? 'Title3' : 'Body2Light'}
+          onClick={() => handleToggleTab('written')}
+        />
       </Flex>
 
-      {newRequestList && newRequestList.length > 0 ? (
-        <Flex direction="column" gap={8} padding="30px 20px">
-          {newRequestList.map((request) => (
-            <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
-              <Card borderRadius={12} padding="6px">
-                <PetInfo
-                  themeVariant="medium"
-                  image={request.petImage}
-                  name={request.petName}
-                  breed={request.petBreed}
-                  age={request.petAge}
-                  neutering={request.petNeutering}
+      {selectedTab === 'new' && 
+        (newRequestList && newRequestList.length > 0 ? (
+          <Flex direction="column" gap={8} padding="30px 20px">
+            {newRequestList.map((request) => (
+              <Flex key={request.requestId} onClick={() => handleRequestClick(request.requestId)}>
+                <Card borderRadius={12} padding="6px">
+                  <PetInfo
+                    themeVariant="medium"
+                    image={request.petImage}
+                    name={request.petName}
+                    breed={request.petBreed}
+                    age={request.petAge}
+                    neutering={request.petNeutering}
 
-                  // TODO : gender, weight API 수정 필요함
-                  gender="F"
-                  weight={7.3}
-                />
-              </Card>
-            </Flex>
-          ))}
-        </Flex>
-      ) : (
-        // TODO : 임시 대체뷰 수정 필요
-        <FlexGrow>
-          <Text>새로운 요청이 없어요.</Text>
-        </FlexGrow>
-      )}
+                    // TODO : gender, weight API 수정 필요함
+                    gender="F"
+                    weight={7.3}
+                  />
+                </Card>
+              </Flex>
+            ))}
+          </Flex>
+        ) : (
+          // TODO : 임시 대체뷰 수정 필요
+          <FlexGrow>
+            <Text>새로운 요청이 없어요.</Text>
+          </FlexGrow>
+        ))
+      }
 
       <SalonNavbar />
 

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, SalonTag, Text, theme, WidthFitFlex } from "@duri-fe/ui"
 import { useGetApprovedQuotationList, useGetNewRequestList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
+import { DetailQuotation } from "@salon/components/quotation/DetailQuotation";
 import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
 
@@ -145,7 +146,7 @@ const QuotationPage = () => {
           </Modal>
 
           <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'approved')} toggleModal={closeModal}>
-            견적서 작성 완료!!
+            <DetailQuotation requestId={selectedRequestId} closeModal={closeModal} />
           </Modal>
         </>
       }

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, Text, theme } from "@duri-fe/ui"
-import { useGetNewRequestList, useModal } from "@duri-fe/utils";
+import { Card, Flex, MobileLayout, Modal, PetInfo, SalonNavbar, SalonTag, Text, theme, WidthFitFlex } from "@duri-fe/ui"
+import { useGetApprovedQuotationList, useGetNewRequestList, useModal } from "@duri-fe/utils";
 import styled from "@emotion/styled";
 import { DetailRequest } from "@salon/components/quotation/DetailRequest";
 import { TabBarItem } from "@salon/components/quotation/TabBarItem"
@@ -11,12 +11,20 @@ const QuotationPage = () => {
   const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState<string>('new')
   const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
+  const [selectedQuotationId, setSelectedQuotationId] = useState<number | null>(null);
   const { isOpenModal, openModal, closeModal } = useModal();
+
   const { data: newRequestList } = useGetNewRequestList();
+  const { data: approvedQuotationList } = useGetApprovedQuotationList();
 
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
     openModal();
+  }
+
+  const handleQuotationClick = (requestId: number) => {
+    setSelectedQuotationId(requestId);
+    // openModal();
   }
 
   const handleNavigate = () => {
@@ -58,13 +66,13 @@ const QuotationPage = () => {
         />
         <TabBarItem 
           label="답장한 견적" 
-          selected={selectedTab === 'written'} 
-          typo={selectedTab === 'written' ? 'Title3' : 'Body2Light'}
-          onClick={() => handleToggleTab('written')}
+          selected={selectedTab === 'approved'} 
+          typo={selectedTab === 'approved' ? 'Title3' : 'Body2Light'}
+          onClick={() => handleToggleTab('approved')}
         />
       </Flex>
 
-      {selectedTab === 'new' && 
+      {selectedTab === 'new' ? 
         (newRequestList && newRequestList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
             {newRequestList.map((request) => (
@@ -91,14 +99,59 @@ const QuotationPage = () => {
           <FlexGrow>
             <Text>새로운 요청이 없어요.</Text>
           </FlexGrow>
+        )) : (
+          approvedQuotationList && approvedQuotationList.length > 0 ? (
+            <Flex direction="column" gap={8} padding="30px 20px">
+            {approvedQuotationList.map((quotation) => (
+              <Flex key={quotation.requestId} onClick={() => handleQuotationClick(quotation.requestId)}>
+                <Card borderRadius={12} padding="6px" direction="row">
+                  <PetInfo
+                    themeVariant="medium"
+                    image={quotation.petImage}
+                    name={quotation.petName}
+                    breed={quotation.petBreed}
+                    age={quotation.petAge}
+                    neutering={quotation.petNeutering}
+
+                    // TODO : gender, weight API 수정 필요함
+                    gender="F"
+                    weight={7.3}
+                  />
+                  <TagWrapper margin="0 14px">
+                    <SalonTag
+                      content={quotation.status === 'approved' ? '수락됨' : quotation.status === 'expired' ? '만료됨' : '대기중'}
+                      bg={quotation.status === 'approved' ? theme.palette.Normal100 : theme.palette.Gray50} 
+                      colorCode={quotation.status === 'approved' ? theme.palette.Normal700 : theme.palette.Gray300} 
+                      typo="Label3"
+                      borderRadius={99}
+                      width="auto"
+                      height="auto"
+                      padding="6px 10px"
+                    />
+                  </TagWrapper>
+                </Card>
+              </Flex>
+            ))}
+          </Flex>
+        ) : (
+          // TODO : 임시 대체뷰 수정 필요
+          <FlexGrow>
+            <Text>답장한 견적이 없어요.</Text>
+          </FlexGrow>
         ))
       }
 
       <SalonNavbar />
 
       {selectedRequestId &&
-        <Modal title='요청서' margin="20px" isOpen={isOpenModal} toggleModal={closeModal}>
+        <Modal title='요청서' margin="20px" isOpen={isOpenModal && (selectedTab === 'new')} toggleModal={closeModal}>
           <DetailRequest requestId={selectedRequestId} closeModal={closeModal} />
+        </Modal>
+      }
+
+      {selectedQuotationId &&
+        <Modal title='견적서' margin="20px" isOpen={isOpenModal && (selectedTab === 'approved')} toggleModal={closeModal}>
+          <DetailRequest requestId={selectedQuotationId} closeModal={closeModal} />
         </Modal>
       }
     </MobileLayout>
@@ -107,6 +160,10 @@ const QuotationPage = () => {
 
 const FlexGrow = styled(Flex)`
   flex-grow: 1;
+`
+
+const TagWrapper = styled(WidthFitFlex)`
+  flex-shrink: 0;
 `
 
 export default QuotationPage;

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -125,7 +125,7 @@ const QuotationPage = () => {
                       typo="Label3"
                       borderRadius={99}
                       width="auto"
-                      height="auto"
+                      height={26}
                       padding="6px 10px"
                     />
                   </TagWrapper>

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -22,10 +22,17 @@ import styled from '@emotion/styled';
 import { DetailQuotation } from '@salon/components/quotation/DetailQuotation';
 import { DetailRequest } from '@salon/components/quotation/DetailRequest';
 import { TabBarItem } from '@salon/components/quotation/TabBarItem';
+import {
+  differenceInDays,
+  differenceInHours,
+  differenceInMinutes,
+} from 'date-fns';
 
 const QuotationPage = () => {
   const navigate = useNavigate();
+
   const [selectedTab, setSelectedTab] = useState<string>('new');
+
   const [selectedRequestId, setSelectedRequestId] = useState<number | null>(
     null,
   );
@@ -34,6 +41,23 @@ const QuotationPage = () => {
 
   const { data: newRequestList } = useGetNewRequestList();
   const { data: approvedQuotationList } = useGetApprovedQuotationList();
+
+  /** n시간 전 출력 */
+  const calculateTimeAgo = (date: string | Date) => {
+    const now = new Date();
+
+    const diffDays = differenceInDays(now, date);
+    const diffHours = differenceInHours(now, date);
+    const diffMinutes = differenceInMinutes(now, date);
+
+    if (diffDays > 0) {
+      return `${diffDays}일 전`;
+    } else if (diffHours > 0) {
+      return `${diffHours}시간 전`;
+    } else {
+      return `${diffMinutes}분 전`;
+    }
+  };
 
   const handleRequestClick = (requestId: number) => {
     setSelectedRequestId(requestId);
@@ -166,7 +190,8 @@ const QuotationPage = () => {
                   />
                 </TagWrapper>
                 <TimeAgoText typo="Caption3" colorCode={theme.palette.Gray300}>
-                  1시간전
+                  {quotation.requestCreatedAt &&
+                    calculateTimeAgo(quotation.requestCreatedAt)}
                 </TimeAgoText>
               </PetInfoCard>
             </Flex>

--- a/apps/salon/src/pages/Quotation/index.tsx
+++ b/apps/salon/src/pages/Quotation/index.tsx
@@ -112,26 +112,36 @@ const QuotationPage = () => {
       {selectedTab === 'new' ? (
         newRequestList && newRequestList.length > 0 ? (
           <Flex direction="column" gap={8} padding="30px 20px">
-            {newRequestList.map((request) => (
-              <Flex
-                key={request.requestId}
-                onClick={() => handleRequestClick(request.requestId)}
-              >
-                <Card borderRadius={12} padding="6px" shadow="none">
-                  <PetInfo
-                    themeVariant="medium"
-                    image={request.petImage}
-                    name={request.petName}
-                    breed={request.petBreed}
-                    age={request.petAge}
-                    neutering={request.petNeutering}
-                    // TODO : gender, weight API 수정 필요함
-                    gender="F"
-                    weight={7.3}
-                  />
-                </Card>
-              </Flex>
-            ))}
+            {newRequestList.map(
+              ({
+                requestId,
+                petImage,
+                petName,
+                petBreed,
+                petAge,
+                petNeutering,
+                petGender,
+                petWeight,
+              }) => (
+                <Flex
+                  key={requestId}
+                  onClick={() => handleRequestClick(requestId)}
+                >
+                  <Card borderRadius={12} padding="6px" shadow="none">
+                    <PetInfo
+                      themeVariant="medium"
+                      image={petImage}
+                      name={petName}
+                      breed={petBreed}
+                      age={petAge}
+                      neutering={petNeutering}
+                      gender={petGender}
+                      weight={petWeight}
+                    />
+                  </Card>
+                </Flex>
+              ),
+            )}
           </Flex>
         ) : (
           // TODO : 임시 대체뷰 수정 필요
@@ -141,61 +151,75 @@ const QuotationPage = () => {
         )
       ) : approvedQuotationList && approvedQuotationList.length > 0 ? (
         <Flex direction="column" gap={8} padding="30px 20px">
-          {approvedQuotationList.map((quotation) => (
-            <Flex
-              key={quotation.requestId}
-              onClick={() => handleRequestClick(quotation.requestId)}
-            >
-              <PetInfoCard
-                borderRadius={12}
-                padding="6px"
-                direction="row"
-                shadow="none"
+          {approvedQuotationList.map(
+            ({
+              requestId,
+              petImage,
+              petName,
+              petBreed,
+              petAge,
+              petNeutering,
+              petGender,
+              petWeight,
+              status,
+              requestCreatedAt,
+            }) => (
+              <Flex
+                key={requestId}
+                onClick={() => handleRequestClick(requestId)}
               >
-                <PetInfo
-                  themeVariant="medium"
-                  image={quotation.petImage}
-                  name={quotation.petName}
-                  breed={quotation.petBreed}
-                  age={quotation.petAge}
-                  neutering={quotation.petNeutering}
-                  // TODO : gender, weight API 수정 필요함
-                  gender="F"
-                  weight={7.3}
-                />
-                <TagWrapper margin="0 14px">
-                  <SalonTag
-                    content={
-                      quotation.status === 'approved'
-                        ? '수락됨'
-                        : quotation.status === 'expired'
-                          ? '만료됨'
-                          : '대기중'
-                    }
-                    bg={
-                      quotation.status === 'approved'
-                        ? theme.palette.Normal100
-                        : theme.palette.Gray50
-                    }
-                    colorCode={
-                      quotation.status === 'approved'
-                        ? theme.palette.Normal700
-                        : theme.palette.Gray300
-                    }
-                    typo="Label3"
-                    borderRadius={99}
-                    width="auto"
-                    height={26}
-                    padding="6px 10px"
+                <PetInfoCard
+                  borderRadius={12}
+                  padding="6px"
+                  direction="row"
+                  shadow="none"
+                >
+                  <PetInfo
+                    themeVariant="medium"
+                    image={petImage}
+                    name={petName}
+                    breed={petBreed}
+                    age={petAge}
+                    neutering={petNeutering}
+                    gender={petGender}
+                    weight={petWeight}
                   />
-                </TagWrapper>
-                <TimeAgoText typo="Caption3" colorCode={theme.palette.Gray300}>
-                  {quotation.requestCreatedAt &&
-                    calculateTimeAgo(quotation.requestCreatedAt)}
-                </TimeAgoText>
-              </PetInfoCard>
-            </Flex>
-          ))}
+                  <TagWrapper margin="0 14px">
+                    <SalonTag
+                      content={
+                        status === 'approved'
+                          ? '수락됨'
+                          : status === 'expired'
+                            ? '만료됨'
+                            : '대기중'
+                      }
+                      bg={
+                        status === 'approved'
+                          ? theme.palette.Normal100
+                          : theme.palette.Gray50
+                      }
+                      colorCode={
+                        status === 'approved'
+                          ? theme.palette.Normal700
+                          : theme.palette.Gray300
+                      }
+                      typo="Label3"
+                      borderRadius={99}
+                      width="auto"
+                      height={26}
+                      padding="6px 10px"
+                    />
+                  </TagWrapper>
+                  <TimeAgoText
+                    typo="Caption3"
+                    colorCode={theme.palette.Gray300}
+                  >
+                    {requestCreatedAt && calculateTimeAgo(requestCreatedAt)}
+                  </TimeAgoText>
+                </PetInfoCard>
+              </Flex>
+            ),
+          )}
         </Flex>
       ) : (
         // TODO : 임시 대체뷰 수정 필요

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -11,6 +11,7 @@ interface CardProps {
   maxHeight?: string;
   children: React.ReactNode;
   bg?: string;
+  className?: string;
 }
 
 export const Card = ({
@@ -23,6 +24,7 @@ export const Card = ({
   padding,
   maxHeight,
   children,
+  className,
 }: CardProps) => {
   return (
     <CardContainer
@@ -34,6 +36,7 @@ export const Card = ({
       borderColor={borderColor}
       maxHeight={maxHeight}
       bg={bg}
+      className={className}
     >
       {children}
     </CardContainer>

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ interface CardProps {
   direction?: string;
   height?: string;
   borderRadius: number;
-  shadow?: 'small' | 'large';
+  shadow?: 'small' | 'large' | 'none';
   padding?: string;
   borderColor?: string;
   maxHeight?: string;
@@ -44,7 +44,9 @@ const CardContainer = styled(Flex)<CardProps>`
   box-shadow: ${({ shadow }) =>
     shadow === 'small'
       ? '0px 0px 4px 0px rgba(0, 0, 0, 0.10)'
-      : '0px 0px 10px 0px rgba(0, 0, 0, 0.10)'};
+      : shadow === 'large'
+        ? '0px 0px 10px 0px rgba(0, 0, 0, 0.10)'
+        : 'none'};
   background-color: ${({ bg }) => bg ?? `${theme.palette.White}`};
   padding: ${({ padding }) => (padding ? `${padding}` : '0px')};
   border: ${({ borderColor }) =>

--- a/packages/ui/src/components/PetInfo/PetInfo.tsx
+++ b/packages/ui/src/components/PetInfo/PetInfo.tsx
@@ -194,7 +194,7 @@ const ProfileImageWrapper = styled(WidthFitFlex)`
 `;
 const PencilWrapper = styled(WidthFitFlex)<{ imageSize: number }>`
   position: absolute;
-  border: 1.094px solid ${theme.palette.White};
+  border: 1px solid ${theme.palette.White};
   padding: 6px;
   top: ${({ imageSize }) => `${imageSize - 32}px`};
   left: ${({ imageSize }) => `${imageSize - 30}px`};

--- a/packages/ui/src/components/PetInfo/PetInfo.tsx
+++ b/packages/ui/src/components/PetInfo/PetInfo.tsx
@@ -83,35 +83,68 @@ export const PetInfo = ({
           </ProfileImageWrapper>
         ) : (
           <ProfileImage
-          borderRadius={imageSize.borderRadius}
-          width={imageSize.width}
-          height={imageSize.height}
-          src={image}
-        />
+            borderRadius={imageSize.borderRadius}
+            width={imageSize.width}
+            height={imageSize.height}
+            src={image}
+          />
         )}
-       <Flex direction="column" gap={gap.horizontal} align="flex-start">
-        <Flex justify='flex-start' gap={8}>
-          <Text typo={typo.name}>{name}</Text>
-          {(dday === 0 || dday) && (
-            <SalonTag content={dday === 0 ? `D-day` : `D-${dday}`} bg={theme.palette.Normal500} colorCode={theme.palette.Black} typo='Label2' padding='8px 10px' height={26} borderRadius={99} />
-          )}
-          {complete && (
-            <SalonTag content='미용 완료' bg={theme.palette.Gray50} colorCode={theme.palette.Gray300} typo='Label2' padding='8px 10px' height={26} borderRadius={99} />
-          )}
-        </Flex>
+        <Flex direction="column" gap={gap.horizontal} align="flex-start">
+          <Flex justify="flex-start" gap={8}>
+            <Text typo={typo.name}>{name}</Text>
+            {(dday === 0 || dday) && (
+              <SalonTag
+                content={dday === 0 ? `D-day` : `D-${dday}`}
+                bg={theme.palette.Normal500}
+                colorCode={theme.palette.Black}
+                typo="Label2"
+                padding="8px 10px"
+                height={26}
+                borderRadius={99}
+              />
+            )}
+            {complete && (
+              <SalonTag
+                content="미용 완료"
+                bg={theme.palette.Gray50}
+                colorCode={theme.palette.Gray300}
+                typo="Label2"
+                padding="8px 10px"
+                height={26}
+                borderRadius={99}
+              />
+            )}
+          </Flex>
           <Text typo={typo.description} colorCode={theme.palette.Gray400}>
-            {parsePetInfo({ age, breed, weight, gender})}
+            {parsePetInfo({ age, breed, weight, gender })}
           </Text>
-          {neutering && <SalonTag content="중성화 완료" padding='4px' />}
+          {neutering && <SalonTag content="중성화 완료" padding="4px" />}
           {groomer && (
-            <Flex direction="column" padding='8px 0 0 0' gap={8} align="flex-start">
-              <Flex justify='flex-start' gap={8}>
-                <Image src={groomer.groomerImage} width={24} height={24} borderRadius={24} />
-                <Text typo="Label2" colorCode={theme.palette.Black}>{groomer.groomerName}</Text>
+            <Flex
+              direction="column"
+              padding="8px 0 0 0"
+              gap={8}
+              align="flex-start"
+            >
+              <Flex justify="flex-start" gap={8}>
+                <Image
+                  src={groomer.groomerImage}
+                  width={24}
+                  height={24}
+                  borderRadius={24}
+                />
+                <Text typo="Label2" colorCode={theme.palette.Black}>
+                  {groomer.groomerName}
+                </Text>
               </Flex>
-              <Flex justify='space-between'>
-                <Text typo="Label2" colorCode={theme.palette.Black}>{groomer.date}</Text>
-                <Text typo="Label3" colorCode={theme.palette.Gray400}>{format(groomer.startTime, 'hh:mm')} ~ {format(groomer.endTime, 'hh:mm')}</Text>
+              <Flex justify="space-between">
+                <Text typo="Label2" colorCode={theme.palette.Black}>
+                  {groomer.date}
+                </Text>
+                <Text typo="Label3" colorCode={theme.palette.Gray400}>
+                  {format(groomer.startTime, 'hh:mm')} ~{' '}
+                  {format(groomer.endTime, 'hh:mm')}
+                </Text>
               </Flex>
             </Flex>
           )}
@@ -163,10 +196,9 @@ const PencilWrapper = styled(WidthFitFlex)<{ imageSize: number }>`
   position: absolute;
   border: 1.094px solid ${theme.palette.White};
   padding: 6px;
-  top: ${({ imageSize }) => `${imageSize-32}px`};
-  left: ${({ imageSize }) => `${imageSize-30}px`};
+  top: ${({ imageSize }) => `${imageSize - 32}px`};
+  left: ${({ imageSize }) => `${imageSize - 30}px`};
 `;
-
 
 interface ThemeVariant {
   imageSize: {

--- a/packages/ui/src/components/PetInfo/PetInfo.tsx
+++ b/packages/ui/src/components/PetInfo/PetInfo.tsx
@@ -2,6 +2,7 @@ import {
   diseaseMapping,
   Flex,
   HeightFitFlex,
+  Image,
   KeyOfTypo,
   Pencil,
   personalityMapping,
@@ -11,7 +12,17 @@ import {
   theme,
   WidthFitFlex,
 } from '@duri-fe/ui';
+import { parsePetInfo } from '@duri-fe/utils';
 import styled from '@emotion/styled';
+import { format } from 'date-fns';
+
+interface GroomerInfoType {
+  groomerName: string;
+  groomerImage: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+}
 
 interface PetInfoType {
   image?: string;
@@ -21,6 +32,8 @@ interface PetInfoType {
   weight: number;
   gender: string;
   neutering?: boolean;
+  dday?: number;
+  groomer?: GroomerInfoType;
   character?: string[];
   diseases?: string[];
   modify?: boolean;
@@ -36,6 +49,8 @@ export const PetInfo = ({
   weight,
   gender,
   neutering,
+  dday,
+  groomer,
   character,
   diseases,
   modify = false,
@@ -73,11 +88,28 @@ export const PetInfo = ({
         />
         )}
        <Flex direction="column" gap={gap.horizontal} align="flex-start">
+        <Flex justify='flex-start' gap={8}>
           <Text typo={typo.name}>{name}</Text>
+          {(dday === 0 || dday) && (
+            <SalonTag content={dday === 0 ? `D-day` : `D-${dday}`} bg={theme.palette.Normal500} colorCode={theme.palette.Black} typo='Label2' padding='8px 10px' height={26} borderRadius={99} />
+          )}
+        </Flex>
           <Text typo={typo.description} colorCode={theme.palette.Gray400}>
-            {breed}, {gender === 'F' ? '여아' : '남아'}, {age}세, {weight}kg
+            {parsePetInfo({ age, breed, weight, gender})}
           </Text>
           {neutering && <SalonTag content="중성화 완료" padding='4px' />}
+          {groomer && (
+            <Flex direction="column" padding='8px 0 0 0' gap={8} align="flex-start">
+              <Flex justify='flex-start' gap={8}>
+                <Image src={groomer.groomerImage} width={24} height={24} borderRadius={24} />
+                <Text typo="Label2" colorCode={theme.palette.Black}>{groomer.groomerName}</Text>
+              </Flex>
+              <Flex justify='space-between'>
+                <Text typo="Label2" colorCode={theme.palette.Black}>{groomer.date}</Text>
+                <Text typo="Label3" colorCode={theme.palette.Gray400}>{format(groomer.startTime, 'hh:mm')} ~ {format(groomer.endTime, 'hh:mm')}</Text>
+              </Flex>
+            </Flex>
+          )}
         </Flex>
       </HeightFitFlex>
       {character && (

--- a/packages/ui/src/components/PetInfo/PetInfo.tsx
+++ b/packages/ui/src/components/PetInfo/PetInfo.tsx
@@ -77,7 +77,7 @@ export const PetInfo = ({
           <Text typo={typo.description} colorCode={theme.palette.Gray400}>
             {breed}, {gender === 'F' ? '여아' : '남아'}, {age}세, {weight}kg
           </Text>
-          {neutering && <SalonTag content="중성화 완료" />}
+          {neutering && <SalonTag content="중성화 완료" padding='4px' />}
         </Flex>
       </HeightFitFlex>
       {character && (

--- a/packages/ui/src/components/PetInfo/PetInfo.tsx
+++ b/packages/ui/src/components/PetInfo/PetInfo.tsx
@@ -33,6 +33,7 @@ interface PetInfoType {
   gender: string;
   neutering?: boolean;
   dday?: number;
+  complete?: boolean;
   groomer?: GroomerInfoType;
   character?: string[];
   diseases?: string[];
@@ -50,6 +51,7 @@ export const PetInfo = ({
   gender,
   neutering,
   dday,
+  complete,
   groomer,
   character,
   diseases,
@@ -92,6 +94,9 @@ export const PetInfo = ({
           <Text typo={typo.name}>{name}</Text>
           {(dday === 0 || dday) && (
             <SalonTag content={dday === 0 ? `D-day` : `D-${dday}`} bg={theme.palette.Normal500} colorCode={theme.palette.Black} typo='Label2' padding='8px 10px' height={26} borderRadius={99} />
+          )}
+          {complete && (
+            <SalonTag content='미용 완료' bg={theme.palette.Gray50} colorCode={theme.palette.Gray300} typo='Label2' padding='8px 10px' height={26} borderRadius={99} />
           )}
         </Flex>
           <Text typo={typo.description} colorCode={theme.palette.Gray400}>

--- a/packages/ui/src/components/Quotation/DetailGrooming.tsx
+++ b/packages/ui/src/components/Quotation/DetailGrooming.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, WidthFitFlex } from '@duri-fe/ui';
+import { Flex, Text, theme, WidthFitFlex } from '@duri-fe/ui';
 
 interface GroomingMenuProps {
     groomingMenu:string[],
@@ -24,7 +24,7 @@ export const DetailGrooming = ({
           <Text typo="Body2">기본 미용</Text>
           <WidthFitFlex direction="column" gap={12} align='end'>
             {groomingMenu.map((item, index) => (
-              <Text typo="Label3" key={index}>
+              <Text typo="Label3" colorCode={theme.palette.Gray500} key={index}>
                 {item}
               </Text>
             ))}
@@ -40,7 +40,7 @@ export const DetailGrooming = ({
           <Text typo="Body2">추가 미용</Text>
           <WidthFitFlex direction="column" gap={12} align='end'>
             {additionalGrooming.map((item, index) => (
-              <Text typo="Label3" key={index}>
+              <Text typo="Label3" colorCode={theme.palette.Gray500} key={index}>
                 {item}
               </Text>
             ))}
@@ -56,7 +56,7 @@ export const DetailGrooming = ({
           <Text typo="Body2">스페셜 케어</Text>
           <WidthFitFlex direction="column" gap={12} align='end'>
             {specialCare.map((item, index) => (
-              <Text typo="Label3" key={index}>
+              <Text typo="Label3" colorCode={theme.palette.Gray500} key={index}>
                 {item}
               </Text>
             ))}
@@ -72,7 +72,7 @@ export const DetailGrooming = ({
           <Text typo="Body2">디자인 컷</Text>
           <WidthFitFlex direction="column" gap={12} align='end'>
             {designCut.map((item, index) => (
-              <Text typo="Label3" key={index}>
+              <Text typo="Label3" colorCode={theme.palette.Gray500} key={index}>
                 {item}
               </Text>
             ))}

--- a/packages/ui/src/components/Quotation/RequestQuotation.tsx
+++ b/packages/ui/src/components/Quotation/RequestQuotation.tsx
@@ -13,8 +13,8 @@ import { format } from 'date-fns';
 
 import { RequestDetailProps } from '../../types';
 
-// import { DetailGrooming } from './DetailGrooming';
-import { DetailGroomingTemp } from './DetailGroomingTemp';
+import { DetailGrooming } from './DetailGrooming';
+// import { DetailGroomingTemp } from './DetailGroomingTemp';
 import { TimeTable } from './Timetable';
 
 const timeList = Array(10)
@@ -97,7 +97,7 @@ export const RequestQuotation = ({
 
       {/** 상세 미용 */}
       <HeightFitFlex direction="column" padding='28px 0'>
-        <DetailGroomingTemp
+        <DetailGrooming
           groomingMenu={groomingMenu}
           additionalGrooming={additionalGrooming}
           specialCare={specialCare}

--- a/packages/ui/src/components/Quotation/ResponseQuotation.tsx
+++ b/packages/ui/src/components/Quotation/ResponseQuotation.tsx
@@ -76,11 +76,12 @@ export const ResponseQuotation = ({
         <Flex direction="column" align="flex-start" padding="0 35.5px" gap={24}>
           <Text typo="Body2">요청사항</Text>
           {isSalon ? (
-            <TextField value={memo} width={266} multiline={true} height={108} onChange={undefined} />
+            <MemoText typo="Label3" colorCode={theme.palette.Gray500}>
+              {memo}
+            </MemoText>
           ) : (
             <TextField value={memo} width={266} multiline={true} height={108} />
           )}
-
         </Flex>
         <Seperator mode="dotted" height="2px" />
         <HeightFitFlex direction="column" gap={18}>
@@ -111,4 +112,8 @@ const SingleLineText = styled(Text)`
 
 const MaxWidthFlex = styled(Flex)`
   max-width: 337px;
+`;
+
+const MemoText = styled(Text)`
+  text-align: start;
 `;

--- a/packages/ui/src/components/Quotation/ResponseQuotation.tsx
+++ b/packages/ui/src/components/Quotation/ResponseQuotation.tsx
@@ -17,9 +17,11 @@ import { DetailGrooming } from './DetailGrooming';
 
 export const ResponseQuotation = ({
   responseList,
+  isSalon = false,
   children,
 }: {
   responseList: ResponseQuotationType;
+  isSalon?: boolean;
   children: React.ReactNode;
 }) => {
   const { groomingMenu, additionalGrooming, specialCare, designCut } =
@@ -73,7 +75,12 @@ export const ResponseQuotation = ({
         <Seperator mode="dotted" height="2px" />
         <Flex direction="column" align="flex-start" padding="0 35.5px" gap={24}>
           <Text typo="Body2">요청사항</Text>
-          <TextField value={memo} width={266} multiline={true} height={108} />
+          {isSalon ? (
+            <TextField value={memo} width={266} multiline={true} height={108} onChange={undefined} />
+          ) : (
+            <TextField value={memo} width={266} multiline={true} height={108} />
+          )}
+
         </Flex>
         <Seperator mode="dotted" height="2px" />
         <HeightFitFlex direction="column" gap={18}>

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -15,7 +15,8 @@ interface TagProps {
   content: string;
   bg?: string;
   borderRadius?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
   typo?: keyof TypeOfTypo;
   colorCode?: string;
   padding?: string;
@@ -25,6 +26,7 @@ export const SalonTag = ({
   content,
   bg,
   borderRadius,
+  width,
   height,
   colorCode = theme.palette.Gray500,
   typo = 'Caption5',
@@ -36,7 +38,7 @@ export const SalonTag = ({
       borderRadius={borderRadius ?? 2}
       padding={padding ?? '5.5px 4px'}
       height={height ?? 20}
-      width={height ?? 20}
+      width={width ?? 20}
     >
       <Text typo={typo} colorCode={colorCode}>
         {content}

--- a/packages/ui/src/data/request.ts
+++ b/packages/ui/src/data/request.ts
@@ -27,10 +27,10 @@ export const defaultRequestDetailData: RequestDetailProps = {
     "info": "강아지 전문 미용사입니다."
   },
   "quotationDetails": {
-    "groomingMenu": "string",
-    "additionalGrooming": "stringaa",
-    "specialCare": "stringaa",
-    "designCut": "stringaa",
+    "groomingMenu": ["string"],
+    "additionalGrooming": ["stringaa"],
+    "specialCare": ["stringaa"],
+    "designCut": ["stringaa"],
     "otherRequests": "stringaaa",
     "day": "2024-12-06",
     "time9": false,

--- a/packages/ui/src/styles/typo.tsx
+++ b/packages/ui/src/styles/typo.tsx
@@ -156,6 +156,13 @@ export const typo = {
     font-weight: 300;
     line-height: normal;
   `,
+  Body2Light: css`
+    /* 스케줄러 이름 텍스트 */
+    font-family: 'Pretendard';
+    font-size: ${calcRem(16)};
+    font-weight: 400;
+    line-height: normal;
+  `,
   Letter: css`
     /* 피드백 텍스트 */
     font-family: 'OwnglyphRyryu';

--- a/packages/ui/src/types/request.ts
+++ b/packages/ui/src/types/request.ts
@@ -40,6 +40,7 @@ interface RequestDetailGroomerType {
   info: string;
 }
 
+/** TODO: string[] 변경시 적용 */
 interface QuotationDetailsType extends TimeType {
   groomingMenu: string;
   additionalGrooming: string;

--- a/packages/ui/src/types/request.ts
+++ b/packages/ui/src/types/request.ts
@@ -40,12 +40,11 @@ interface RequestDetailGroomerType {
   info: string;
 }
 
-/** TODO: string[] 변경시 적용 */
 interface QuotationDetailsType extends TimeType {
-  groomingMenu: string;
-  additionalGrooming: string;
-  specialCare: string;
-  designCut: string;
+  groomingMenu: string[];
+  additionalGrooming: string[];
+  specialCare: string[];
+  designCut: string[];
   otherRequests: string;
   day: string;
 }

--- a/packages/utils/src/apis/salon/hooks/index.ts
+++ b/packages/utils/src/apis/salon/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './home';
 export * from './request';
+export * from './quotation';

--- a/packages/utils/src/apis/salon/hooks/quotation.ts
+++ b/packages/utils/src/apis/salon/hooks/quotation.ts
@@ -1,5 +1,5 @@
-import { postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
-import { useMutation, UseMutationResult } from "@tanstack/react-query"
+import { getApprovedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
+import { useMutation, UseMutationResult, useQuery } from "@tanstack/react-query"
 
 export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['response'], void, PostQuotationRequest> => {
   return useMutation({
@@ -9,4 +9,15 @@ export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['res
       alert('견적서 요청을 실패했습니다.');
     },
   })
+}
+
+export const useGetApprovedQuotationList = () => {
+  const { data } = useQuery({
+    queryKey: ['approvedQuotationList'],
+    queryFn: () => getApprovedQuotationList(),
+    enabled: true,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return { data };
 }

--- a/packages/utils/src/apis/salon/hooks/quotation.ts
+++ b/packages/utils/src/apis/salon/hooks/quotation.ts
@@ -1,4 +1,4 @@
-import { getApprovedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
+import { getApprovedQuotationList, getReservedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
 import { useMutation, UseMutationResult, useQuery } from "@tanstack/react-query"
 
 export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['response'], void, PostQuotationRequest> => {
@@ -15,6 +15,17 @@ export const useGetApprovedQuotationList = () => {
   const { data } = useQuery({
     queryKey: ['approvedQuotationList'],
     queryFn: () => getApprovedQuotationList(),
+    enabled: true,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return { data };
+}
+
+export const useGetReservedQuotationList = () => {
+  const { data } = useQuery({
+    queryKey: ['reservedQuotationList'],
+    queryFn: () => getReservedQuotationList(),
     enabled: true,
     staleTime: 10 * 60 * 1000,
   });

--- a/packages/utils/src/apis/salon/hooks/quotation.ts
+++ b/packages/utils/src/apis/salon/hooks/quotation.ts
@@ -1,0 +1,12 @@
+import { postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
+import { useMutation, UseMutationResult } from "@tanstack/react-query"
+
+export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['response'], void, PostQuotationRequest> => {
+  return useMutation({
+    mutationFn: (request: PostQuotationRequest) => postQuoatation(request),
+    onError: (error) => {
+      console.error(error);
+      alert('견적서 요청을 실패했습니다.');
+    },
+  })
+}

--- a/packages/utils/src/apis/salon/hooks/quotation.ts
+++ b/packages/utils/src/apis/salon/hooks/quotation.ts
@@ -1,4 +1,4 @@
-import { getApprovedQuotationList, getCompletedQuotationList, getReservedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
+import { getApprovedQuotationList, getCompletedQuotationList, getDetailQuotation, getReservedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
 import { useMutation, UseMutationResult, useQuery } from "@tanstack/react-query"
 
 export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['response'], void, PostQuotationRequest> => {
@@ -37,6 +37,17 @@ export const useGetCompletedQuotationList = () => {
   const { data } = useQuery({
     queryKey: ['completedQuotationList'],
     queryFn: () => getCompletedQuotationList(),
+    enabled: true,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return { data };
+}
+
+export const useGetDetailQuotation = (requestId: number) => {
+  const { data } = useQuery({
+    queryKey: ['detailQuotation', requestId],
+    queryFn: () => getDetailQuotation(requestId),
     enabled: true,
     staleTime: 10 * 60 * 1000,
   });

--- a/packages/utils/src/apis/salon/hooks/quotation.ts
+++ b/packages/utils/src/apis/salon/hooks/quotation.ts
@@ -1,4 +1,4 @@
-import { getApprovedQuotationList, getReservedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
+import { getApprovedQuotationList, getCompletedQuotationList, getReservedQuotationList, postQuoatation,PostQuotationRequest, PostQuotationResponse } from "@duri-fe/utils";
 import { useMutation, UseMutationResult, useQuery } from "@tanstack/react-query"
 
 export const usePostQuotation = (): UseMutationResult<PostQuotationResponse['response'], void, PostQuotationRequest> => {
@@ -26,6 +26,17 @@ export const useGetReservedQuotationList = () => {
   const { data } = useQuery({
     queryKey: ['reservedQuotationList'],
     queryFn: () => getReservedQuotationList(),
+    enabled: true,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return { data };
+}
+
+export const useGetCompletedQuotationList = () => {
+  const { data } = useQuery({
+    queryKey: ['completedQuotationList'],
+    queryFn: () => getCompletedQuotationList(),
     enabled: true,
     staleTime: 10 * 60 * 1000,
   });

--- a/packages/utils/src/apis/salon/index.ts
+++ b/packages/utils/src/apis/salon/index.ts
@@ -2,3 +2,4 @@ export * from './hooks';
 export * from './auth';
 export * from './home';
 export * from './request';
+export * from './quotation';

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -1,0 +1,9 @@
+import { salonInstance } from "../axiosConfig";
+import { PostQuotationRequest, PostQuotationResponse } from "../types";
+
+export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
+  console.log(request);
+  const response = await salonInstance.post(`/quotation`, request);
+  console.log(response);
+  return response.data.response;
+}

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -2,8 +2,6 @@ import { salonInstance } from "../axiosConfig";
 import { PostQuotationRequest, PostQuotationResponse } from "../types";
 
 export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
-  console.log(request);
   const response = await salonInstance.post(`/quotation`, request);
-  console.log(response);
   return response.data.response;
 }

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -1,5 +1,5 @@
 import { salonInstance } from "../axiosConfig";
-import { ApprovedQuotationListResponse, CompletedQuotationListResponse, PostQuotationRequest, PostQuotationResponse, ReservedQuotationListResponse } from "../types";
+import { ApprovedQuotationListResponse, CompletedQuotationListResponse, PostQuotationRequest, PostQuotationResponse, QuotationDetailResponse, ReservedQuotationListResponse } from "../types";
 
 export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
   const response = await salonInstance.post(`/quotation`, request);
@@ -18,5 +18,10 @@ export const getReservedQuotationList = async (): Promise<ReservedQuotationListR
 
 export const getCompletedQuotationList = async (): Promise<CompletedQuotationListResponse['response'][]> => {
   const response = await salonInstance.get(`/quotation/request/reservation/complete`);
+  return response.data.response;
+}
+
+export const getDetailQuotation = async (requestId: number): Promise<QuotationDetailResponse['response']> => {
+  const response = await salonInstance.get(`/quotation/${requestId}`);
   return response.data.response;
 }

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -1,7 +1,12 @@
 import { salonInstance } from "../axiosConfig";
-import { PostQuotationRequest, PostQuotationResponse } from "../types";
+import { ApprovedQuotationListResponse, PostQuotationRequest, PostQuotationResponse } from "../types";
 
 export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
   const response = await salonInstance.post(`/quotation`, request);
+  return response.data.response;
+}
+
+export const getApprovedQuotationList = async (): Promise<ApprovedQuotationListResponse['response'][]> => {
+  const response = await salonInstance.get(`/quotation/request/approved`);
   return response.data.response;
 }

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -1,5 +1,5 @@
 import { salonInstance } from "../axiosConfig";
-import { ApprovedQuotationListResponse, PostQuotationRequest, PostQuotationResponse } from "../types";
+import { ApprovedQuotationListResponse, PostQuotationRequest, PostQuotationResponse, ReservedQuotationListResponse } from "../types";
 
 export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
   const response = await salonInstance.post(`/quotation`, request);
@@ -8,5 +8,10 @@ export const postQuoatation = async (request: PostQuotationRequest): Promise<Pos
 
 export const getApprovedQuotationList = async (): Promise<ApprovedQuotationListResponse['response'][]> => {
   const response = await salonInstance.get(`/quotation/request/approved`);
+  return response.data.response;
+}
+
+export const getReservedQuotationList = async (): Promise<ReservedQuotationListResponse['response'][]> => {
+  const response = await salonInstance.get(`/quotation/request/reservation`);
   return response.data.response;
 }

--- a/packages/utils/src/apis/salon/quotation.ts
+++ b/packages/utils/src/apis/salon/quotation.ts
@@ -1,5 +1,5 @@
 import { salonInstance } from "../axiosConfig";
-import { ApprovedQuotationListResponse, PostQuotationRequest, PostQuotationResponse, ReservedQuotationListResponse } from "../types";
+import { ApprovedQuotationListResponse, CompletedQuotationListResponse, PostQuotationRequest, PostQuotationResponse, ReservedQuotationListResponse } from "../types";
 
 export const postQuoatation = async (request: PostQuotationRequest): Promise<PostQuotationResponse['response']> => {
   const response = await salonInstance.post(`/quotation`, request);
@@ -13,5 +13,10 @@ export const getApprovedQuotationList = async (): Promise<ApprovedQuotationListR
 
 export const getReservedQuotationList = async (): Promise<ReservedQuotationListResponse['response'][]> => {
   const response = await salonInstance.get(`/quotation/request/reservation`);
+  return response.data.response;
+}
+
+export const getCompletedQuotationList = async (): Promise<CompletedQuotationListResponse['response'][]> => {
+  const response = await salonInstance.get(`/quotation/request/reservation/complete`);
   return response.data.response;
 }

--- a/packages/utils/src/apis/salon/request.ts
+++ b/packages/utils/src/apis/salon/request.ts
@@ -3,7 +3,7 @@ import { NewRequestListResponse, RequestDetailResponse } from "../types";
 
 /** 새로운 견적요청 리스트 */
 export const getNewRequestList = async (): Promise<NewRequestListResponse['response'][]>  => {
-  const response = await salonInstance.get(`/quotation/request/new?shopId=1`);
+  const response = await salonInstance.get(`/quotation/request/new`);
   return response.data.response;
 }
 

--- a/packages/utils/src/apis/salon/request.ts
+++ b/packages/utils/src/apis/salon/request.ts
@@ -1,6 +1,7 @@
 import { salonInstance } from "../axiosConfig"
 import { NewRequestListResponse, RequestDetailResponse } from "../types";
 
+/** 새로운 견적요청 리스트 */
 export const getNewRequestList = async (): Promise<NewRequestListResponse['response'][]>  => {
   const response = await salonInstance.get(`/quotation/request/new?shopId=1`);
   return response.data.response;

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -1,3 +1,5 @@
+import { BaseResponse } from "./base";
+
 export interface TimeType {
   time9: boolean;
   time10: boolean;
@@ -11,6 +13,7 @@ export interface TimeType {
   time18: boolean;
 }
 
+/** [POST] 견적 요청서 작성 request */
 export interface RequestProps extends TimeType {
   petId?: number;
   menu: string[];
@@ -22,6 +25,7 @@ export interface RequestProps extends TimeType {
   shopIds: number[];
 }
 
+/** [GET] 견적 요청서 리스트 response */
 export interface NewRequestListResponse {
   response: {
     requestId: number;
@@ -38,6 +42,7 @@ export interface NewRequestListResponse {
   }
 }
 
+/** [GET] 견적 요청서 세부 response */
 export interface RequestDetailResponse {
   response: {
     userName: string;
@@ -68,6 +73,7 @@ export interface RequestDetailGroomerType {
   info: string;
 }
 
+/** TODO: string[] 변경시 적용 */
 export interface QuotationDetailsType extends TimeType {
   groomingMenu: string;
   additionalGrooming: string;
@@ -75,4 +81,26 @@ export interface QuotationDetailsType extends TimeType {
   designCut: string;
   otherRequests: string;
   day: string;
+}
+
+/** [POST] 견적서 작성 request */
+export interface PostQuotationRequest {
+  requestId: number;
+  priceDetail: {
+    groomingPrice: number;
+    additionalPrice: number;
+    specialCarePrice: number;
+    designPrice: number;
+    customPrice: number;
+    totalPrice: number;
+  };
+  memo: string;
+  startDateTime: string;
+  endDateTime: string;
+}
+
+export interface PostQuotationResponse extends BaseResponse {
+  response: {
+    data: string;
+  }
 }

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -1,4 +1,4 @@
-import { BaseResponse } from "./base";
+import { BaseResponse } from './base';
 
 export interface TimeType {
   time9: boolean;
@@ -38,8 +38,8 @@ export interface NewRequestListResponse {
     petNeutering: boolean;
     petCharacter: string[];
     petDiseases: string[];
-    requestCreatedAt: Date | string | null
-  }
+    requestCreatedAt: Date | string | null;
+  };
 }
 
 /** [GET] 견적 요청서 세부 response */
@@ -50,7 +50,7 @@ export interface RequestDetailResponse {
     pet: RequestDetailPetType;
     groomer: RequestDetailGroomerType;
     quotationDetails: QuotationDetailsType;
-  }
+  };
 }
 
 export interface RequestDetailPetType {
@@ -101,13 +101,13 @@ export interface PostQuotationRequest {
 export interface PostQuotationResponse extends BaseResponse {
   response: {
     data: string;
-  }
+  };
 }
 
 export interface ApprovedQuotationListResponse extends BaseResponse {
-  response: (NewRequestListResponse['response'] & {
+  response: NewRequestListResponse['response'] & {
     status: string;
-  })
+  };
 }
 
 export interface ReservedQuotationListResponse extends BaseResponse {
@@ -123,7 +123,7 @@ export interface ReservedQuotationListResponse extends BaseResponse {
     date: string;
     startTime: string;
     endTime: string;
-  }
+  };
 }
 
 export interface CompletedQuotationListResponse extends BaseResponse {
@@ -139,18 +139,18 @@ export interface CompletedQuotationListResponse extends BaseResponse {
     date: string;
     startTime: string;
     endTime: string;
-  }
+  };
 }
 
 export interface QuotationDetailResponse extends BaseResponse {
   response: {
     shopDetail: ShopDetailType;
-    quotationCreatedAt: string; 
+    quotationCreatedAt: string;
     petDetail: RequestDetailPetType;
     menuDetail: QuotationDetailsType;
     quotation: PostQuotationRequest;
     status: string;
-  }
+  };
 }
 
 interface ShopDetailType {

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -104,3 +104,9 @@ export interface PostQuotationResponse extends BaseResponse {
     data: string;
   }
 }
+
+export interface ApprovedQuotationListResponse extends BaseResponse {
+  response: (NewRequestListResponse['response'] & {
+    status: string;
+  })
+}

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -36,6 +36,8 @@ export interface NewRequestListResponse {
     petAge: number;
     petBreed: string;
     petNeutering: boolean;
+    petGender: string;
+    petWeight: number;
     petCharacter: string[];
     petDiseases: string[];
     requestCreatedAt: Date | string | null;

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -142,3 +142,21 @@ export interface CompletedQuotationListResponse extends BaseResponse {
     endTime: string;
   }
 }
+
+export interface QuotationDetailResponse extends BaseResponse {
+  response: {
+    shopDetail: ShopDetailType;
+    quotationCreatedAt: string; 
+    petDetail: RequestDetailPetType;
+    menuDetail: QuotationDetailsType;
+    quotation: PostQuotationRequest;
+    status: string;
+  }
+}
+
+interface ShopDetailType {
+  shopName: string;
+  shopAddress: string;
+  shopPhone: string;
+  groomerName: string;
+}

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -111,36 +111,23 @@ export interface ApprovedQuotationListResponse extends BaseResponse {
   })
 }
 
-/*
-      "requestId": 2,
-      "userId": 2,
-      "petId": 2,
-      "petDetailResponse": {
-        "image": "https://example.com/dog2.jpg",
-        "name": "초코",
-        "age": 3,
-        "gender": "F",
-        "breed": "푸들",
-        "weight": 10,
-        "neutering": true,
-        "character": [
-          "사람을 잘 따름",
-          "조용한 성격"
-        ],
-        "diseases": [
-          "딱히 없음"
-        ],
-        "lastGrooming": "2023-10-14T15:00:00.000+00:00"
-      },
-      "groomerName": "한지민",
-      "groomerImage": "https://example.com/groomer1.jpg",
-      "totalPrice": 220,
-      "dday": 0,
-      "date": "2024-12-07",
-      "startTime": "00:31:30",
-      "endTime": "00:31:30"
-*/
 export interface ReservedQuotationListResponse extends BaseResponse {
+  response: {
+    requestId: number;
+    userId: number;
+    petId: number;
+    petDetailResponse: RequestDetailPetType;
+    groomerName: string;
+    groomerImage: string;
+    totalPrice: number;
+    dday: number;
+    date: string;
+    startTime: string;
+    endTime: string;
+  }
+}
+
+export interface CompletedQuotationListResponse extends BaseResponse {
   response: {
     requestId: number;
     userId: number;

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -110,3 +110,48 @@ export interface ApprovedQuotationListResponse extends BaseResponse {
     status: string;
   })
 }
+
+/*
+      "requestId": 2,
+      "userId": 2,
+      "petId": 2,
+      "petDetailResponse": {
+        "image": "https://example.com/dog2.jpg",
+        "name": "초코",
+        "age": 3,
+        "gender": "F",
+        "breed": "푸들",
+        "weight": 10,
+        "neutering": true,
+        "character": [
+          "사람을 잘 따름",
+          "조용한 성격"
+        ],
+        "diseases": [
+          "딱히 없음"
+        ],
+        "lastGrooming": "2023-10-14T15:00:00.000+00:00"
+      },
+      "groomerName": "한지민",
+      "groomerImage": "https://example.com/groomer1.jpg",
+      "totalPrice": 220,
+      "dday": 0,
+      "date": "2024-12-07",
+      "startTime": "00:31:30",
+      "endTime": "00:31:30"
+*/
+export interface ReservedQuotationListResponse extends BaseResponse {
+  response: {
+    requestId: number;
+    userId: number;
+    petId: number;
+    petDetailResponse: RequestDetailPetType;
+    groomerName: string;
+    groomerImage: string;
+    totalPrice: number;
+    dday: number;
+    date: string;
+    startTime: string;
+    endTime: string;
+  }
+}

--- a/packages/utils/src/apis/types/quotation.ts
+++ b/packages/utils/src/apis/types/quotation.ts
@@ -73,12 +73,11 @@ export interface RequestDetailGroomerType {
   info: string;
 }
 
-/** TODO: string[] 변경시 적용 */
 export interface QuotationDetailsType extends TimeType {
-  groomingMenu: string;
-  additionalGrooming: string;
-  specialCare: string;
-  designCut: string;
+  groomingMenu: string[];
+  additionalGrooming: string[];
+  specialCare: string[];
+  designCut: string[];
   otherRequests: string;
   day: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,6 +543,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.15.0"
     "@vitejs/plugin-react": "npm:^4.3.3"
     axios: "npm:^1.7.7"
+    date-fns: "npm:^4.1.0"
     eslint: "npm:8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-react: "npm:^7.37.2"


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-180, DURI-179, DURI-344, DURI-345, DURI-346, DURI-347

## PR 개요

### 미용사 견적서 조회/예약/완료된 시술 UI
- 견적서 관련 리스트 UI, 클릭 시 모달 UI 작업 완료

### petInfo 컴포넌트 수정
- props에 따라 여러 배리에이션이 가능합니다. 스샷 참조 !
- dday : number 넣으면 디데이 렌더링 (0이면 D-day)
- complete : dday 있어도 complete 있으면 미용완료로 뜸
- groomer : 미용사, 예약시간 관련 정보 떄려넣기
- 대기중, 5일 전 이런것들은 PetInfo에 넣기 애매해서 그걸 감싸는 Card에 넣음!

### 견적 관련 API 연동
- API 연동은 했으나 데이터가 없음... 대체뷰 필요 !!
- 목업 데이터 작업은 해놨으니 테스트 시 msw true 설정 필요 =.=

### Card 컴포넌트 수정
- className props 추가...!!
- shadow='none' props 추가 (default는 small)

## Screenshots

<img width="297" alt="image" src="https://github.com/user-attachments/assets/d765ddea-7831-4fa1-b6fc-af03489f39b3" />
<img width="291" alt="image" src="https://github.com/user-attachments/assets/69f8f3c5-7114-4c15-9ee3-bbbfa1c2381f" />
<img width="301" alt="image" src="https://github.com/user-attachments/assets/80e2c29c-e3d3-406f-876b-49ebecaf4eb0" />
<img width="290" alt="image" src="https://github.com/user-attachments/assets/87b81ccd-2365-4492-9ccb-0b664c489f5e" />

