### PR TITLE
[hotfix] React의 SPA 방식으로 인한 vercel 경로 인식 불가능

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  }

--- a/apps/duri/vercel.json
+++ b/apps/duri/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  }

--- a/apps/salon/vercel.json
+++ b/apps/salon/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- vercel이 경로 인식이 불가능해 주소창에서 다른 페이지로 넘어갈 수 없었음.

## PR 개요

- vercel.json 파일을 만들어 관련 설정

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->
