### PR TITLE
[feat] mypage pet delete API 연결 및 UI 구현, 훅 onSuccess에 alert 추가

### DIFF
--- a/apps/duri/src/App.tsx
+++ b/apps/duri/src/App.tsx
@@ -37,6 +37,8 @@ import PrivateRoute from '@components/PrivateRoute';
 
 import 'react-spring-bottom-sheet/dist/style.css';
 
+import MyPetRegisterPage from './pages/My/MyPetRegister';
+
 function App() {
   return (
     <BrowserRouter>
@@ -72,6 +74,7 @@ function App() {
           <Route path="/my" element={<MyPage />} />
           <Route path="/my/pet" element={<MyPetPage />} />
           <Route path="/my/pet/modify" element={<MyPetModifyPage />} />
+          <Route path="/my/pet/register" element={<MyPetRegisterPage />} />
           <Route path="/my/info" element={<MyInfoModifyPage />} />
           <Route path="/my/shop" element={<MyShopPage />} />
           <Route path="/my/history" element={<MyHistoryPage />} />

--- a/apps/duri/src/components/my/Status.tsx
+++ b/apps/duri/src/components/my/Status.tsx
@@ -16,11 +16,13 @@ export const Status = ({ reservationCnt, noShowCnt }: StatusProps) => {
     >
       <Flex direction="column" gap={15}>
         <Text typo="Caption2">누적예약</Text>
-        <Text typo="Body2">{reservationCnt}건</Text>
+        <Text typo="Body2">
+          {reservationCnt === -1 ? ' - ' : reservationCnt}건
+        </Text>
       </Flex>
       <BorderFlex direction="column" gap={15}>
         <Text typo="Caption2">노쇼</Text>
-        <Text typo="Body2">{noShowCnt}건</Text>
+        <Text typo="Body2">{noShowCnt === -1 ? ' - ' : noShowCnt}건</Text>
       </BorderFlex>
       <FlexButton direction="column" gap={9}>
         <Text typo="Caption2">고객센터</Text>
@@ -32,9 +34,9 @@ export const Status = ({ reservationCnt, noShowCnt }: StatusProps) => {
 
 const FlexButton = styled(Flex)`
   cursor: pointer;
-`
+`;
 
 const BorderFlex = styled(Flex)`
-    border-left: solid 1.5px ${theme.palette.Normal600};
-    border-right: solid 1.5px ${theme.palette.Normal600};
-`
+  border-left: solid 1.5px ${theme.palette.Normal600};
+  border-right: solid 1.5px ${theme.palette.Normal600};
+`;

--- a/apps/duri/src/components/my/modify/ModifyPetInfoCard.tsx
+++ b/apps/duri/src/components/my/modify/ModifyPetInfoCard.tsx
@@ -36,7 +36,7 @@ export const ModifyPetInfoCard = () => {
   }, [petListData]);
 
   return (
-    <Flex direction="column" gap={20} padding="0 20px">
+    <Flex direction="column" gap={20}>
       {petListInfo &&
         petListInfo.map(
           ({

--- a/apps/duri/src/components/my/modify/ModifyPetInfoCard.tsx
+++ b/apps/duri/src/components/my/modify/ModifyPetInfoCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Flex } from '@duri-fe/ui';
+import { Button, Flex, HeightFitFlex, Text, theme } from '@duri-fe/ui';
 import { useGetPetListInfo } from '@duri-fe/utils';
 
 import { SwipeCard } from './SwipeCard';
@@ -20,15 +21,22 @@ interface PetListInfo {
 }
 
 export const ModifyPetInfoCard = () => {
+  const navigate = useNavigate();
+
   const { data: petListData } = useGetPetListInfo();
+
   const [petListInfo, setPetListInfo] = useState<PetListInfo[]>([]);
+
+  const handleClickRegisterButton = () => {
+    navigate('/my/pet/register');
+  };
+
   useEffect(() => {
     if (petListData) setPetListInfo(petListData);
-    console.log(petListData);
-  });
+  }, [petListData]);
 
   return (
-    <Flex direction="column" gap={20} padding="0 0 114px 0">
+    <Flex direction="column" gap={20} padding="0 20px">
       {petListInfo &&
         petListInfo.map(
           ({
@@ -58,6 +66,34 @@ export const ModifyPetInfoCard = () => {
             />
           ),
         )}
+      {petListInfo.length === 0 && (
+        <Flex
+          backgroundColor={theme.palette.White}
+          borderRadius={16}
+          width={334}
+          height={163}
+          padding="12px 30px 16px 12px"
+          gap={16}
+          direction='column'
+        >
+          <Text typo="Label3" colorCode={theme.palette.Gray300}>
+            앗! 등록된 반려견이 없어요.
+          </Text>
+          <HeightFitFlex>
+            <Button
+              typo="Label4"
+              fontColor={theme.palette.White}
+              onClick={handleClickRegisterButton}
+              bg={theme.palette.Black}
+              width="135px"
+              padding="10px"
+              borderRadius="8px"
+            >
+              마이펫 등록하러가기
+            </Button>
+          </HeightFitFlex>
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/apps/duri/src/components/my/modify/SwipeCard.tsx
+++ b/apps/duri/src/components/my/modify/SwipeCard.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Button, Flex, Modal, PetInfo, Text, theme, Trash } from '@duri-fe/ui';
-import { useModal } from '@duri-fe/utils';
+import { useDeletePetInfo, useModal } from '@duri-fe/utils';
 import styled from '@emotion/styled';
 
 interface PetListInfo {
@@ -32,11 +32,16 @@ export const SwipeCard = ({
 }: PetListInfo) => {
   const navigate = useNavigate();
   const { isOpenModal, toggleModal } = useModal();
+  const { mutateAsync: deletePetInfo } = useDeletePetInfo();
+
   const [isSwiped, setIsSwiped] = useState<boolean>(false);
   const [swipePosition, setSwipePosition] = useState<number>(0); // 화면에 반영될 스와이프 위치
+
   const handleDelete = () => {
     toggleModal();
+
     //삭제 api 호출
+    deletePetInfo(id);
   };
   const handleNotDelete = () => {
     toggleModal();
@@ -150,7 +155,7 @@ export const SwipeCard = ({
         </SwipeWrapper>
       </SwipeContainer>
 
-      <Modal isOpen={isOpenModal} toggleModal={toggleModal}>
+      <Modal isOpen={isOpenModal} toggleModal={toggleModal} closeIcon={false}>
         <Flex direction="column" gap={5}>
           <Flex direction="column">
             <Text typo="Body2">반려견 정보 삭제 시</Text>
@@ -177,11 +182,12 @@ export const SwipeCard = ({
             </Button>
             <Button
               typo="Body3"
-              bg={theme.palette.Black}
+              bg={theme.palette.Alert}
               fontColor={theme.palette.White}
               width="145px"
               height="47px"
               borderRadius="8px"
+              onClick={handleDelete}
             >
               삭제할게요
             </Button>

--- a/apps/duri/src/components/my/register/PetRegisterForm.tsx
+++ b/apps/duri/src/components/my/register/PetRegisterForm.tsx
@@ -6,16 +6,24 @@ import {
   NEUTERED_FORM_OPTION_LIST,
 } from '@duri/constants';
 import { FormData } from '@duri/pages/My/MyPetModify';
-import { Button, Dropdown, Flex, Text, theme, WidthFitFlex } from '@duri-fe/ui';
+import {
+  Button,
+  Dropdown,
+  Flex,
+  Text,
+  TextField,
+  theme,
+  WidthFitFlex,
+} from '@duri-fe/ui';
 
-import { PetDiseaseModify } from './PetDiseaseModify';
-import { PetPersonalityModify } from './PetPersonalityModify';
+import { PetDiseaseModify } from '../modify/PetDiseaseModify';
+import { PetPersonalityModify } from '../modify/PetPersonalityModify';
 
 const integerList = Array.from({ length: 41 }, (_, i) => i.toString()); // 정수 리스트
 const decimalList = Array.from({ length: 10 }, (_, i) => i.toString()); // 소수 리스트
 const ageList = Array.from({ length: 26 }, (_, i) => i);
 
-export const PetModifyForm = ({
+export const PetRegisterForm = ({
   control,
   setValue,
   getValues,
@@ -28,12 +36,15 @@ export const PetModifyForm = ({
   const handleAgeSelect = (value: string | number) => {
     if (typeof value === 'number') setValue('age', value);
   };
+
   const handleBreedSelect = (value: string | number) => {
     if (typeof value === 'string') setValue('breed', value);
   };
+
   const handleGenderSelect = (value: string | number) => {
     if (typeof value === 'string') setValue('gender', value);
   };
+
   const handleNeuterSelect = (value: string | number | boolean) => {
     if (typeof value === 'boolean') setValue('neutering', value);
   };
@@ -45,7 +56,15 @@ export const PetModifyForm = ({
         <Controller
           name="name"
           control={control}
-          render={({ field }) => <Text typo="Body3">{field.value}</Text>}
+          render={({ field }) => (
+            <TextField
+              isNoBorder
+              {...field}
+              width={114}
+              placeholder="이름 입력"
+              placeholderTypo={theme.typo.Caption3}
+            />
+          )}
         />
       </Flex>
       <Flex justify="flex-start" gap={65}>
@@ -53,10 +72,10 @@ export const PetModifyForm = ({
         <Controller
           name="breed"
           control={control}
-          render={({ field }) => (
+          render={() => (
             <Dropdown
               options={BREEDS}
-              defaultValue={field.value}
+              defaultValue="견종 입력"
               width={114}
               onSelect={handleBreedSelect}
             />
@@ -145,10 +164,10 @@ export const PetModifyForm = ({
         <Controller
           name="age"
           control={control}
-          render={({ field }) => (
+          render={() => (
             <Dropdown
               options={ageList}
-              defaultValue={`${field.value}살`}
+              defaultValue={0}
               width={114}
               onSelect={handleAgeSelect}
               suffix="살"

--- a/apps/duri/src/components/onboarding/index.tsx
+++ b/apps/duri/src/components/onboarding/index.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 import { BREEDS_MAPPING } from '@duri/constants';
-import { Button, Flex, StatusBar, theme, Toast } from '@duri-fe/ui';
+import { Button, Flex, StatusBar, theme } from '@duri-fe/ui';
 import { usePostPetInfo } from '@duri-fe/utils';
 import styled from '@emotion/styled';
 
@@ -219,7 +219,6 @@ const MultiStepForm = () => {
             </Button>
           ))}
       </Flex>
-      <Toast />
     </Flex>
   );
 };

--- a/apps/duri/src/components/quotation/RequestInfo.tsx
+++ b/apps/duri/src/components/quotation/RequestInfo.tsx
@@ -1,5 +1,6 @@
 import { Flex, Modal, NextArrow, Text, theme } from '@duri-fe/ui';
 import { useModal } from '@duri-fe/utils';
+import styled from '@emotion/styled';
 import { format } from 'date-fns';
 
 import { RequestDetailQuotation } from './RequestDetailQuotation';
@@ -10,9 +11,11 @@ interface RequestInfoProps {
   expiredAt: Date | null;
   expired?: boolean;
   margin?: string;
+  shopName: string;
 }
 
 export const RequestInfo = ({
+  shopName,
   requestId,
   createdAt,
   expiredAt,
@@ -28,15 +31,15 @@ export const RequestInfo = ({
       margin={margin ?? `${margin}`}
       onClick={toggleModal}
     >
-      <Flex gap={8} justify="flex-start">
+      <FlexButton gap={8} justify="flex-start">
         <Text
           typo="Title3"
           colorCode={expired ? theme.palette.Gray300 : theme.palette.Normal700}
         >
-          요청서{requestId}
+          {shopName}
         </Text>
         <NextArrow width={22} height={23} />
-      </Flex>
+      </FlexButton>
       <Flex direction="column" gap={12}>
         <Flex justify="space-between">
           <Text typo="Label4" colorCode={theme.palette.Gray300}>
@@ -73,3 +76,7 @@ export const RequestInfo = ({
     </Flex>
   );
 };
+
+const FlexButton = styled(Flex)`
+  cursor: pointer;
+`;

--- a/apps/duri/src/components/quotation/RequestItem.tsx
+++ b/apps/duri/src/components/quotation/RequestItem.tsx
@@ -15,7 +15,7 @@ export const RequestItem = ({
 }: RequestItemType) => {
   const navigate = useNavigate();
   const handleNavigate = () => {
-    navigate(`/quotation/${quotationReqId}`, {state: requestId}); 
+    navigate(`/quotation/${quotationReqId}`, { state: requestId });
     //URL에서는 요청 자체 id가 뜨게 하고, 실제 세부조회에서는 요청서의 id를 전달해서 조회할 수 있도록
   };
 
@@ -32,6 +32,11 @@ export const RequestItem = ({
             requestId={requestId}
             createdAt={createdAt}
             expiredAt={expiredAt}
+            shopName={
+              shops.length > 1
+                ? `${shops[0].shopName} 외 ${shops.length - 1}`
+                : `${shops[0].shopName}`
+            }
             margin="0 0 20px 0"
           />
           <Seperator height="2px" colorCode={theme.palette.Gray50} />
@@ -55,6 +60,7 @@ export const RequestItem = ({
       ) : (
         <Card borderRadius={16} shadow="small" padding="20px 14px">
           <RequestInfo
+            shopName={shops[0]?.shopName ?? '정보없음'}
             requestId={requestId}
             createdAt={createdAt}
             expiredAt={expiredAt}
@@ -63,11 +69,11 @@ export const RequestItem = ({
           <Seperator height="2px" />
           <Flex justify="flex-start" padding="0 11px" margin="20px 0">
             <Text typo="Caption3" colorCode={theme.palette.Gray300}>
-              {shops && shops.length > 1
-                ? `${shops[0]?.shopName} 외 ${shops.length - 1}`
-                : shops[0]?.shopName === undefined
-                  ? '정보 없음'
-                  : `${shops[0]?.shopName}`}
+              {shops && shops.length > 0
+                ? shops.length === 1
+                  ? shops[0]?.shopName ?? '정보 없음'
+                  : shops.map((shop) => shop.shopName).join(', ')
+                : '정보 없음'}
             </Text>
           </Flex>
           <Button

--- a/apps/duri/src/constants/pet.ts
+++ b/apps/duri/src/constants/pet.ts
@@ -83,3 +83,14 @@ export const NEUTERED_OPTION_LIST = [
     label: '아니요, 아직 안했어요.',
   },
 ];
+
+export const NEUTERED_FORM_OPTION_LIST = [
+  {
+    key: true,
+    label: '완료',
+  },
+  {
+    key: false,
+    label: '미완료',
+  },
+];

--- a/apps/duri/src/constants/request.ts
+++ b/apps/duri/src/constants/request.ts
@@ -18,5 +18,5 @@ export const DEFAULT_REQUEST_INFO = {
   time16: false,
   time17: false,
   time18: false,
-  shopIds: [5],
+  shopIds: [],
 };

--- a/apps/duri/src/pages/My/MyPet.tsx
+++ b/apps/duri/src/pages/My/MyPet.tsx
@@ -14,7 +14,7 @@ const MyPetPage = () => {
         backIcon
         onClickBack={() => navigate('/my')}
       />
-      <ModifyPetInfoCard />
+      {<ModifyPetInfoCard />}
       <DuriNavbar />
     </MobileLayout>
   );

--- a/apps/duri/src/pages/My/MyPetModify.tsx
+++ b/apps/duri/src/pages/My/MyPetModify.tsx
@@ -45,11 +45,17 @@ const MyPetModifyPage = () => {
     mode: 'onChange',
   });
 
+  useEffect(()=>{
+    if(!location.state) {
+      navigate('/my/pet/register')
+    }
+  })
+
   useEffect(() => {
     if (modifySuccess) {
       navigate('/my/pet', { state: petId });
     }
-  });
+  },[modifySuccess]);
 
   useEffect(() => {
     if (getPetDetailData) {

--- a/apps/duri/src/pages/My/MyPetRegister.tsx
+++ b/apps/duri/src/pages/My/MyPetRegister.tsx
@@ -1,0 +1,101 @@
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import { PetRegisterForm } from '@duri/components/my/register/PetRegisterForm';
+import { BREEDS_MAPPING } from '@duri/constants';
+import {
+  Button,
+  DuriNavbar,
+  Flex,
+  Header,
+  MobileLayout,
+  theme,
+} from '@duri-fe/ui';
+import { usePostPetInfo } from '@duri-fe/utils';
+import styled from '@emotion/styled';
+
+export interface FormData {
+  id: number;
+  name: string;
+  image: File | null;
+  breed: string;
+  age: number;
+  weight: number;
+  gender: string;
+  neutering?: boolean;
+  lastGrooming?: string | null;
+  character: string[];
+  diseases: string[];
+}
+
+const MyPetRegisterPage = () => {
+  const navigate = useNavigate();
+
+  //펫 등록 훅
+  const { mutate: postPetInfo } = usePostPetInfo(() => {
+    window.location.href = '/my/pet';
+  }); //반려견 정보 등록 hook
+
+  const { control, handleSubmit, setValue, getValues } = useForm<FormData>({
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: FormData) => {
+    // breed 값 업데이트
+    setValue('breed', BREEDS_MAPPING[data.breed]);
+
+    // 요청 데이터 생성
+    const updatedData = {
+      name: data.name,
+      breed: BREEDS_MAPPING[data.breed],
+      age: data.age,
+      weight: data.weight,
+      gender: data.gender,
+      neutering: data.neutering ?? false,
+      character: data.character,
+      diseases: data.diseases,
+    };
+
+    // API 연결
+    postPetInfo(updatedData);
+  };
+
+  return (
+    <MobileLayout backgroundColor={theme.palette.Gray_White}>
+      <Header
+        title="마이펫 정보 등록"
+        titleAlign="start"
+        backIcon
+        onClickBack={() => navigate('/my/pet')}
+      />
+      <Flex direction="column" margin="0 0 100px">
+        <Flex direction="column" padding="0 20px" margin="0 0 30px 0">
+          <PetRegisterForm
+            control={control}
+            getValues={getValues}
+            setValue={setValue}
+          />
+        </Flex>
+
+        <BottomButton
+          borderRadius="0px"
+          bg={theme.palette.Black}
+          fontColor={theme.palette.White}
+          onClick={handleSubmit(onSubmit)}
+        >
+          등록 완료
+        </BottomButton>
+      </Flex>
+      <DuriNavbar />
+    </MobileLayout>
+  );
+};
+
+export default MyPetRegisterPage;
+
+const BottomButton = styled(Button)`
+  position: sticky;
+  bottom: 92px;
+  left: 0;
+  z-index: 999;
+`;

--- a/apps/duri/src/pages/My/index.tsx
+++ b/apps/duri/src/pages/My/index.tsx
@@ -5,9 +5,11 @@ import { PetInfoCard } from '@duri/components/my/PetInfoCard';
 import { Status } from '@duri/components/my/Status';
 import { UserInfo } from '@duri/components/my/UserInfo';
 import {
+  Button,
   DuriNavbar,
   Flex,
   Header,
+  HeightFitFlex,
   MobileLayout,
   Scissors,
   Store,
@@ -43,9 +45,15 @@ const MyPage = () => {
     localStorage.removeItem('authorization_user');
     navigate('/login');
   };
+
+  const handleClickRegisterButton = () => {
+    navigate('/my/pet/register');
+  };
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
   useEffect(() => {
     if (petListData) setPetInfo(petListData[0]);
   }, [petListData]);
@@ -54,86 +62,112 @@ const MyPage = () => {
     <MobileLayout backgroundColor={theme.palette.Gray_White}>
       <Header />
       <Flex direction="column" padding="0 18px" margin="0 0 100px 0">
-        {userInfo ? (
-          <>
-            <UserInfo
-              name={userInfo.name}
-              phone={userInfo.phone}
-              profileImg={userInfo.profileImg}
-            />
-            <Status
-              reservationCnt={userInfo.reservationCount}
-              noShowCnt={userInfo.noShowCount}
-            />
-            {petInfo ? (
-              <PetInfoCard
-                petId={petInfo.id}
-                age={petInfo.age}
-                name={petInfo.name}
-                breed={petInfo.breed}
-                gender={petInfo.gender}
-                neutering={
-                  petInfo.neutering === undefined ? false : petInfo.neutering
-                }
-                weight={petInfo.weight}
-                imageURL={petInfo.image === null ? '' : petInfo.image}
+        <>
+          {userInfo ? (
+            <>
+              <UserInfo
+                name={userInfo.name}
+                phone={userInfo.phone}
+                profileImg={userInfo.profileImg}
               />
-            ) : (
-              <Flex
-                direction="column"
-                borderRadius={12}
-                padding="25px 22px 27px 13px"
-                height={168}
-                backgroundColor={theme.palette.White}
+              <Status
+                reservationCnt={userInfo.reservationCount}
+                noShowCnt={userInfo.noShowCount}
+              />
+            </>
+          ) : (
+            <Flex
+              direction="column"
+              borderRadius={12}
+              padding="25px 22px 27px 13px"
+              height={168}
+              backgroundColor={theme.palette.White}
+              margin="0 0 10px"
+            >
+              <Text typo="Caption4" colorCode={theme.palette.Gray300}>
+                등록된 유저 정보가 없습니다.
+              </Text>
+            </Flex>
+          )}
+
+          {petInfo ? (
+            <PetInfoCard
+              petId={petInfo.id}
+              age={petInfo.age}
+              name={petInfo.name}
+              breed={petInfo.breed}
+              gender={petInfo.gender}
+              neutering={
+                petInfo.neutering === undefined ? false : petInfo.neutering
+              }
+              weight={petInfo.weight}
+              imageURL={petInfo.image === null ? '' : petInfo.image}
+            />
+          ) : (
+            <HeightFitFlex
+              direction="column"
+              borderRadius={12}
+              padding="25px 22px 27px 13px"
+              height={168}
+              backgroundColor={theme.palette.White}
+              gap={16}
+            >
+              <Text typo="Label3" colorCode={theme.palette.Gray300}>
+                앗! 등록된 반려견이 없어요.
+              </Text>
+              <Button
+                typo="Label4"
+                fontColor={theme.palette.White}
+                onClick={handleClickRegisterButton}
+                bg={theme.palette.Black}
+                width="135px"
+                padding="10px"
+                borderRadius="8px"
               >
-                <Text typo="Caption4" colorCode={theme.palette.Gray300}>
-                  등록된 반려견 정보가 없습니다.
-                </Text>
-              </Flex>
-            )}
-            <Flex direction="column" margin="8px 0" gap={8}>
-              <Flex gap={10}>
-                <FlexButton
-                  padding="13px 35px"
-                  backgroundColor={theme.palette.White}
-                  borderRadius={8}
-                  gap={5}
-                  onClick={() => handleNavigate('/my/shop')}
-                >
-                  <Store width={28} height={28} />
-                  <Text typo="Label1">단골가게</Text>
-                </FlexButton>
-                <FlexButton
-                  padding="15px 35px"
-                  backgroundColor={theme.palette.White}
-                  borderRadius={8}
-                  gap={5}
-                  onClick={() => handleNavigate('/my/history')}
-                >
-                  <Scissors width={24} height={24} />
-                  <Text typo="Label1">이용기록</Text>
-                </FlexButton>
-              </Flex>
+                마이펫 등록하러가기
+              </Button>
+            </HeightFitFlex>
+          )}
+          <Flex direction="column" margin="8px 0" gap={8}>
+            <Flex gap={10}>
               <FlexButton
                 padding="13px 35px"
                 backgroundColor={theme.palette.White}
                 borderRadius={8}
-                gap={10}
-                onClick={() => handleNavigate('/my/review')}
+                gap={5}
+                onClick={() => handleNavigate('/my/shop')}
               >
-                <Write width={18} height={18} />
-                <Text typo="Label1">내가 쓴 후기</Text>
+                <Store width={28} height={28} />
+                <Text typo="Label1">단골가게</Text>
+              </FlexButton>
+              <FlexButton
+                padding="15px 35px"
+                backgroundColor={theme.palette.White}
+                borderRadius={8}
+                gap={5}
+                onClick={() => handleNavigate('/my/history')}
+              >
+                <Scissors width={24} height={24} />
+                <Text typo="Label1">이용기록</Text>
               </FlexButton>
             </Flex>
-            <FlexButton margin="40px 0 0 0" onClick={logout}>
-              <Text typo="Caption2" colorCode={theme.palette.Gray300}>
-                로그아웃
-              </Text>
+            <FlexButton
+              padding="13px 35px"
+              backgroundColor={theme.palette.White}
+              borderRadius={8}
+              gap={10}
+              onClick={() => handleNavigate('/my/review')}
+            >
+              <Write width={18} height={18} />
+              <Text typo="Label1">내가 쓴 후기</Text>
             </FlexButton>
-          </>
-        ) : (
-          <Text colorCode={theme.palette.Gray300}>유저 정보가 없습니다.</Text>
-        )}
+          </Flex>
+          <FlexButton margin="40px 0 0 0" onClick={logout}>
+            <Text typo="Caption2" colorCode={theme.palette.Gray300}>
+              로그아웃
+            </Text>
+          </FlexButton>
+        </>
       </Flex>
       <DuriNavbar />
     </MobileLayout>

--- a/apps/duri/src/pages/Quotation/QuotationDetail.tsx
+++ b/apps/duri/src/pages/Quotation/QuotationDetail.tsx
@@ -84,19 +84,26 @@ const QuotationDetailPage = () => {
       />
       <Flex direction="column" padding="0 20px" margin="0 0 100px 0">
         <Card borderRadius={16} padding="26px 28px">
-          <RequestInfo
-            requestId={Number(requestId)}
-            createdAt={
-              quotationListData?.createdAt === undefined
-                ? null
-                : new Date(quotationListData?.createdAt)
-            }
-            expiredAt={
-              quotationListData?.expiredAt === undefined
-                ? null
-                : new Date(quotationListData?.expiredAt)
-            }
-          />
+          {quotationListData && (
+            <RequestInfo
+              shopName={
+                quotationListData.quotations?.length > 1
+                  ? `${quotationListData.quotations[0].shopName} 외 ${quotationListData.quotations?.length - 1}`
+                  : `${quotationListData.quotations[0].shopName}`
+              }
+              requestId={Number(requestId)}
+              createdAt={
+                quotationListData.createdAt === undefined
+                  ? null
+                  : new Date(quotationListData.createdAt)
+              }
+              expiredAt={
+                quotationListData.expiredAt === undefined
+                  ? null
+                  : new Date(quotationListData.expiredAt)
+              }
+            />
+          )}
         </Card>
         <>
           <Flex

--- a/apps/duri/src/pages/Request/index.tsx
+++ b/apps/duri/src/pages/Request/index.tsx
@@ -85,11 +85,6 @@ const RequestPage = () => {
   };
 
   const handleSaveButtonClick = () => {
-    setRequestInfo((prev) => ({
-      ...prev,
-      shopIds: shopIdList,
-    }));
-
     request(requestInfo);
   };
 
@@ -102,7 +97,7 @@ const RequestPage = () => {
     window.scrollTo(0, 0);
     setRequestInfo((prev) => ({
       ...prev,
-      shopIds: location.state?.shopIds,
+      shopIds: shopIdList,
     }));
   }, []);
 

--- a/packages/utils/src/apis/duri/hooks/my.ts
+++ b/packages/utils/src/apis/duri/hooks/my.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import {
+  deletePetInfo,
   getMyReviews,
   getPetDetailInfo,
   getPetListInfo,
@@ -48,7 +49,9 @@ export const usePutPetInfo = () => {
     mutationKey: ['putPetInfo'],
     mutationFn: ({ petId, formData }: { petId: number; formData: FormData }) =>
       putPetInfo(petId, formData),
-    // onSuccess: () => handleNavigate(),
+    onSuccess: () => {
+        alert('펫 정보가 수정되었습니다.');
+    },
     onError: (error) => console.log(error),
   });
 };
@@ -93,5 +96,19 @@ export const useGetVisitHistory = () => {
     queryKey: ['getVisitHistory'],
     queryFn: () => getVisitHistory(),
     staleTime: 1000 * 60 * 10,
+  });
+};
+
+export const useDeletePetInfo = () => {
+  return useMutation({
+    mutationKey: ['deletePetInfo'],
+    mutationFn: (petId: number) => deletePetInfo(petId),
+    onSuccess: () => {
+      setTimeout(() => {
+        alert('펫 정보가 삭제되었습니다.');
+        window.location.reload();
+      }, 2000)
+    },
+    onError: (error) => console.log(error),
   });
 };

--- a/packages/utils/src/apis/duri/hooks/onboarding.ts
+++ b/packages/utils/src/apis/duri/hooks/onboarding.ts
@@ -1,29 +1,27 @@
-import { toast } from 'react-toastify';
-
 import { useMutation } from '@tanstack/react-query';
 
-import { Flex } from '../../../../../ui';
 import { postPetInfo } from '../onboarding';
 
 export const usePostPetInfo = (handleNavigate: () => void) => {
-  const notify = () => {
-    toast(
-      <Flex justify="space-between">
-        <span>빈려견 정보가 저장되었습니다.</span>
-      </Flex>,
-      { position: 'bottom-center' },
-    );
-  };
+  // const notify = () => {
+  //   toast(
+  //     <Flex justify="space-between">
+  //       <span>빈려견 정보가 저장되었습니다.</span>
+  //     </Flex>,
+  //     { position: 'bottom-center' },
+  //   );
+  // };
 
   const { mutate } = useMutation({
     mutationKey: ['postPetInfo'],
     mutationFn: postPetInfo,
     onSuccess: (response) => {
       if (response) {
-        notify();
+        // notify();
+        alert('빈려견 정보가 저장되었습니다.');
         setTimeout(() => {
           handleNavigate();
-        }, 1800);
+        }, 1000);
       }
     },
     onError: (error) => {

--- a/packages/utils/src/apis/duri/hooks/request.ts
+++ b/packages/utils/src/apis/duri/hooks/request.ts
@@ -11,6 +11,7 @@ export const usePostRequestQuotation = () => {
   return useMutation<RequestResponse, Error, RequestProps>({
     mutationFn: (request: RequestProps) => postRequestQuotation(request),
     onSuccess: () => {
+      alert('견적서 요청을 성공했습니다.');
       window.location.href = '/quotation';
     },
     onError: (error) => {

--- a/packages/utils/src/apis/duri/hooks/review.ts
+++ b/packages/utils/src/apis/duri/hooks/review.ts
@@ -13,6 +13,7 @@ export const usePostReview = () => {
     mutationFn: ({ quotationId, formData }: PostReviewProps) =>
       postReview(quotationId, formData),
     onSuccess: () => {
+      alert('리뷰가 등록되었습니다.');
       window.location.href = '/my/review';
     },
     onError: (error) => {
@@ -27,6 +28,7 @@ export const usePutReview = (handleNavigate: () => void) => {
     mutationFn: ({ reviewId, formData }: PutReviewProps) =>
       putReview(reviewId, formData),
     onSuccess: () => {
+      alert('리뷰가 수정되었습니다.');
       handleNavigate();
     },
     onError: (error) => {
@@ -40,6 +42,7 @@ export const useDeleteReview = (handleNavigate: () => void) => {
     mutationKey: ['deleteReview'],
     mutationFn: (reviewId: number) => deleteReview(reviewId),
     onSuccess: () => {
+      alert('리뷰가 삭제되었습니다.');
       handleNavigate();
     },
     onError: (error) => {

--- a/packages/utils/src/apis/duri/my.ts
+++ b/packages/utils/src/apis/duri/my.ts
@@ -1,6 +1,7 @@
 import { duriInstance } from '@duri-fe/utils';
 
 import {
+  DeletePetResponse,
   MyReviewResponseType,
   PetInfo,
   PetListInfo,
@@ -85,4 +86,11 @@ export const getVisitHistory = async (): Promise<
 > => {
   const response = await duriInstance.get('/user/history');
   return response.data.response;
+};
+
+export const deletePetInfo = async (
+  petId: number,
+): Promise<DeletePetResponse> => {
+  const { data } = await duriInstance.put(`/user/pet/delete/${petId}`);
+  return data;
 };

--- a/packages/utils/src/apis/duri/payment.ts
+++ b/packages/utils/src/apis/duri/payment.ts
@@ -57,6 +57,5 @@ export const postPaymentConfirm = async (
   paymentData: PostPaymentProps,
 ): Promise<PostPaymentResponse> => {
   const response = await duriInstance.post('/payments/confirm', paymentData);
-  console.log("결제 axios: ",response.data);
   return response.data;
 };

--- a/packages/utils/src/apis/types/my.ts
+++ b/packages/utils/src/apis/types/my.ts
@@ -149,3 +149,8 @@ export interface GroomerAndShopProfileResponse extends BaseResponse {
     shopProfileDetail: ShopInfoType;
   };
 }
+
+//펫정보 삭제 응답
+export interface DeletePetResponse extends BaseResponse {
+  response: string;
+}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- mypage delete API 연결 및 UI 구현

## PR 개요

- 마이페이지 > 펫 정보 삭제 api 연결
- 펫 정보 삭제 시 등록하러 가기 UI 대체뷰 구현
- 마이페이지 인덱스에서 대체뷰 구현
- 펫 재등록 페이지 UI 구현 및 API 연결
- mutation 훅에 성공 시 alert 추가

## Screenshots
<img width="368" alt="image" src="https://github.com/user-attachments/assets/66140dfa-9df2-4e65-9268-6c706db2f3eb" />
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c9402cea-28b9-453c-9765-792a32e856ac" />
<img width="367" alt="image" src="https://github.com/user-attachments/assets/038bb9ce-d53b-4966-a021-22a76c6fb7ba" />
